### PR TITLE
Make Scala Code More Idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following options are mapped to the following options of the HadoopCryptoLed
   * "magic" is mapped to "hadoopcryptoledger.bitcoinblockinputformat.filter.magic"
   * "maxblockSize" is mapped to "hadoopcryptoledger.bitcoinblockinputformat.maxblocksize"
   * "useDirectBuffer" is mapped to "hadoopcryptoledeger.bitcoinblockinputformat.usedirectbuffer"
-  * "isSplitable" is mapped to "hadoopcryptoledeger.bitcoinblockinputformat.issplitable"
+  * "isSplittable" is mapped to "hadoopcryptoledeger.bitcoinblockinputformat.issplitable"
   * "readAuxPOW" is mapped to "hadoopcryptoledeger.bitcoinblockinputformat.readauxpow"
   * "enrich" adds the transaction hash to each transaction in the Bitcoin block
 * Ethereum and Altcoins

--- a/build.sbt
+++ b/build.sbt
@@ -1,62 +1,46 @@
-
-
 import sbt._
 import Keys._
-import scala._
-
 
 lazy val root = (project in file("."))
-.settings(
-       organization := "com.github.zuinnote",
+  .settings(
+    organization := "com.github.zuinnote",
+
     name := "spark-hadoopcryptoledger-ds",
-    version := "1.1.2"
-)
- .configs( IntegrationTest )
-  .settings( Defaults.itSettings : _*)
 
+    version := "1.1.2",
 
-publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))
+    scalaVersion := "2.11.8",
 
-crossScalaVersions := Seq("2.10.5", "2.11.7")
+    crossScalaVersions := Seq("2.10.5", "2.11.8"),
 
-scalacOptions += "-target:jvm-1.7"
+    libraryDependencies ++= Seq(
+      "com.github.zuinnote"      % "hadoopcryptoledger-fileformat"  % "1.1.2" % "compile",
 
-javaOptions += "-Xmx3G"
+      "org.bouncycastle"         % "bcprov-ext-jdk15on"             % "1.58"  % "provided",
+      "org.apache.spark"        %% "spark-core"                     % "1.5.0" % "provided",
+      "org.apache.spark"        %% "spark-sql"                      % "1.5.0" % "provided",
+      "org.apache.hadoop"        % "hadoop-client"                  % "2.7.0" % "provided",
+      "org.apache.logging.log4j" % "log4j-api"                      % "2.4.1" % "provided",
 
-fork := true
+      "org.scalatest"           %% "scalatest"                      % "3.0.1" % "test,it",
 
-resolvers += Resolver.mavenLocal
+      "javax.servlet"            % "javax.servlet-api"              % "3.0.1" % "it",
+      "org.apache.spark"        %% "spark-core"                     % "2.0.1" % "it",
+      "org.apache.spark"        %% "spark-sql"                      % "2.0.1" % "it",
+      "org.apache.hadoop"        % "hadoop-common"                  % "2.7.0" % "it" classifier "" classifier "tests",
+      "org.apache.hadoop"        % "hadoop-hdfs"                    % "2.7.0" % "it" classifier "" classifier "tests",
+      "org.apache.hadoop"        % "hadoop-minicluster"             % "2.7.0" % "it"
+    ),
 
+    publishTo := Some(Resolver.file("file", new File(Path.userHome.absolutePath + "/.m2/repository"))),
 
-jacoco.settings
+    scalacOptions += "-target:jvm-1.7",
 
-itJacoco.settings
+    javaOptions += "-Xmx3G",
 
+    fork := true,
 
-libraryDependencies += "com.github.zuinnote" % "hadoopcryptoledger-fileformat" % "1.1.2" % "compile"
-
-libraryDependencies += "org.bouncycastle" % "bcprov-ext-jdk15on" % "1.58" % "provided"
-
-libraryDependencies += "org.apache.spark" %% "spark-core" % "1.5.0" % "provided"
-
-libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.5.0" % "provided"
-
-libraryDependencies += "org.apache.hadoop" % "hadoop-client" % "2.7.0" % "provided"
-
-libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1" % "provided"
-
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test,it"
-
-libraryDependencies += "javax.servlet" % "javax.servlet-api" % "3.0.1" % "it"
-
-
-
-libraryDependencies += "org.apache.spark" %% "spark-core" % "2.0.1" % "it"
-
-libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.0.1" % "it"
-
-libraryDependencies += "org.apache.hadoop" % "hadoop-common" % "2.7.0" % "it" classifier "" classifier "tests"
-
-libraryDependencies += "org.apache.hadoop" % "hadoop-hdfs" % "2.7.0" % "it" classifier "" classifier "tests"
-
-libraryDependencies += "org.apache.hadoop" % "hadoop-minicluster" % "2.7.0" % "it"
+    resolvers += Resolver.mavenLocal
+  )
+  .configs(IntegrationTest)
+  .settings(Defaults.itSettings: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -14,22 +14,22 @@ lazy val root = (project in file("."))
     crossScalaVersions := Seq("2.10.5", "2.11.8"),
 
     libraryDependencies ++= Seq(
-      "com.github.zuinnote"      % "hadoopcryptoledger-fileformat"  % "1.1.2" % "compile",
+      "com.github.zuinnote"       % "hadoopcryptoledger-fileformat"  % "1.1.2" % "compile",
 
-      "org.bouncycastle"         % "bcprov-ext-jdk15on"             % "1.58"  % "provided",
-      "org.apache.spark"        %% "spark-core"                     % "1.5.0" % "provided",
-      "org.apache.spark"        %% "spark-sql"                      % "1.5.0" % "provided",
-      "org.apache.hadoop"        % "hadoop-client"                  % "2.7.0" % "provided",
-      "org.apache.logging.log4j" % "log4j-api"                      % "2.4.1" % "provided",
+      "org.bouncycastle"          % "bcprov-ext-jdk15on"             % "1.58"  % "provided",
+      "org.apache.spark"         %% "spark-core"                     % "1.5.0" % "provided",
+      "org.apache.spark"         %% "spark-sql"                      % "1.5.0" % "provided",
+      "org.apache.hadoop"         % "hadoop-client"                  % "2.7.0" % "provided",
+      "org.apache.logging.log4j"  % "log4j-api"                      % "2.4.1" % "provided",
 
-      "org.scalatest"           %% "scalatest"                      % "3.0.1" % "test,it",
+      "org.scalatest"            %% "scalatest"                      % "3.0.1" % "test,it",
 
-      "javax.servlet"            % "javax.servlet-api"              % "3.0.1" % "it",
-      "org.apache.spark"        %% "spark-core"                     % "2.0.1" % "it",
-      "org.apache.spark"        %% "spark-sql"                      % "2.0.1" % "it",
-      "org.apache.hadoop"        % "hadoop-common"                  % "2.7.0" % "it" classifier "" classifier "tests",
-      "org.apache.hadoop"        % "hadoop-hdfs"                    % "2.7.0" % "it" classifier "" classifier "tests",
-      "org.apache.hadoop"        % "hadoop-minicluster"             % "2.7.0" % "it"
+      "javax.servlet"             % "javax.servlet-api"              % "3.0.1" % "it",
+      "org.apache.spark"         %% "spark-core"                     % "2.0.1" % "it",
+      "org.apache.spark"         %% "spark-sql"                      % "2.0.1" % "it",
+      "org.apache.hadoop"         % "hadoop-common"                  % "2.7.0" % "it" classifier "" classifier "tests",
+      "org.apache.hadoop"         % "hadoop-hdfs"                    % "2.7.0" % "it" classifier "" classifier "tests",
+      "org.apache.hadoop"         % "hadoop-minicluster"             % "2.7.0" % "it"
     ),
 
     publishTo := Some(Resolver.file("file", new File(Path.userHome.absolutePath + "/.m2/repository"))),

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "1.3.11")
 
-addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.1.6")
+addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.0.3")

--- a/src/it/scala/org/zuinnote/spark/bitcoin/block/SparkBitcoinBlockDSSparkMasterIntegrationSpec.scala
+++ b/src/it/scala/org/zuinnote/spark/bitcoin/block/SparkBitcoinBlockDSSparkMasterIntegrationSpec.scala
@@ -23,8 +23,8 @@
 package org.zuinnote.spark.bitcoin.block
 
 import java.io.{File, IOException}
-import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, SimpleFileVisitor}
+import java.nio.file.attribute.BasicFileAttributes
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -34,7 +34,7 @@ import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.functions._
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, GivenWhenThen, Matchers}
-import org.zuinnote.spark.bitcoin.model._
+import org.zuinnote.spark.bitcoin.model.{BitcoinBlock, BitcoinBlockWithAuxPOW, EnrichedBitcoinBlock, EnrichedBitcoinBlockWithAuxPOW}
 
 import scala.collection.mutable
 
@@ -119,206 +119,205 @@ class SparkBitcoinBlockDSSparkMasterIntegrationSpec extends FlatSpec with Before
     super.afterAll()
   }
 
+  "The genesis block on DFS" should "be fully read in dataframe" in {
+    Given("Genesis Block on DFSCluster")
+    // create input directory
+    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR, true)
+    dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
+    // copy bitcoin blocks
+    val classLoader = getClass.getClassLoader
+    // put testdata on DFS
+    val fileName: String = "genesis.blk"
+    val fileNameFullLocal = classLoader.getResource("testdata/" + fileName).getFile
+    val inputFile = new Path(fileNameFullLocal)
+    dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
+    When("reading Genesis block using datasource")
+    val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri.toString + DFS_INPUT_DIR_NAME)
+    Then("all fields should be readable trough Spark SQL")
+    // check first if structure is correct
+    assert("blockSize" == df.columns(0))
+    assert("magicNo" == df.columns(1))
+    assert("version" == df.columns(2))
+    assert("time" == df.columns(3))
+    assert("bits" == df.columns(4))
+    assert("nonce" == df.columns(5))
+    assert("transactionCounter" == df.columns(6))
+    assert("hashPrevBlock" == df.columns(7))
+    assert("hashMerkleRoot" == df.columns(8))
+    assert("transactions" == df.columns(9))
+    // validate block data
+    val blockSize = df.select("blockSize").collect
+    assert(285 == blockSize(0).getInt(0))
+    val magicNo = df.select("magicNo").collect
+    val magicNoExpected: Array[Byte] = Array(0xF9.toByte, 0xBE.toByte, 0xB4.toByte, 0xD9.toByte)
+    assert(magicNoExpected.deep == magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val version = df.select("version").collect
+    assert(1 == version(0).getInt(0))
+    val time = df.select("time").collect
+    assert(1231006505 == time(0).getInt(0))
+    val bits = df.select("bits").collect
+    val bitsExpected: Array[Byte] = Array(0xFF.toByte, 0xFF.toByte, 0x00.toByte, 0x1D.toByte)
+    assert(bitsExpected.deep == bits(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val nonce = df.select("nonce").collect
+    assert(2083236893 == nonce(0).getInt(0))
+    val transactionCounter = df.select("transactionCounter").collect
+    assert(1 == transactionCounter(0).getLong(0))
+    val hashPrevBlock = df.select("hashPrevBlock").collect
+    val hashPrevBlockExpected: Array[Byte] = Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)
+    assert(hashPrevBlockExpected.deep == hashPrevBlock(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val hashMerkleRoot = df.select("hashMerkleRoot").collect
+    val hashMerkleRootExpected: Array[Byte] = Array(0x3B.toByte, 0xA3.toByte, 0xED.toByte, 0xFD.toByte, 0x7A.toByte, 0x7B.toByte, 0x12.toByte, 0xB2.toByte, 0x7A.toByte, 0xC7.toByte, 0x2C.toByte, 0x3E.toByte, 0x67.toByte, 0x76.toByte, 0x8F.toByte, 0x61.toByte, 0x7F.toByte,
+      0xC8.toByte, 0x1B.toByte, 0xC3.toByte, 0x88.toByte, 0x8A.toByte, 0x51.toByte, 0x32.toByte, 0x3A.toByte, 0x9F.toByte, 0xB8.toByte, 0xAA.toByte, 0x4B.toByte, 0x1E.toByte, 0x5E.toByte, 0x4A.toByte)
+    assert(hashMerkleRootExpected.deep == hashMerkleRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
+    // validate transactions
+    val transactionsDF = df.select(explode(df("transactions")).alias("transactions"))
+    // one transaction
+    val transactionsDFCount = transactionsDF.count
+    assert(1 == transactionsDFCount)
+    val transactionsVersion = transactionsDF.select("transactions.version").collect
+    assert(1 == transactionsVersion(0).getInt(0))
+    val inCounter = transactionsDF.select("transactions.inCounter").collect
+    val inCounterExpected: Array[Byte] = Array(0x01.toByte)
+    assert(inCounterExpected.deep == inCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val outCounter = transactionsDF.select("transactions.outCounter").collect
+    val outCounterExpected: Array[Byte] = Array(0x01.toByte)
+    assert(outCounterExpected.deep == outCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val transactionsLockTime = transactionsDF.select("transactions.lockTime").collect
+    assert(0 == transactionsLockTime(0).getInt(0))
+    val transactionsLOIDF = transactionsDF.select(explode(transactionsDF("transactions.listOfInputs")).alias("listOfInputs"))
+    val prevTransactionHash = transactionsLOIDF.select("listOfInputs.prevTransactionHash").collect
+    val prevTransactionHashExpected: Array[Byte] = Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)
+    assert(prevTransactionHashExpected.deep == prevTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val previousTxOutIndex = transactionsLOIDF.select("listOfInputs.previousTxOutIndex").collect
+    assert(4294967295L == previousTxOutIndex(0).getLong(0))
+    val txInScriptLength = transactionsLOIDF.select("listOfInputs.txInScriptLength").collect
+    val txInScriptLengthExpected: Array[Byte] = Array(0x4D.toByte)
+    assert(txInScriptLengthExpected.deep == txInScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val txInScript = transactionsLOIDF.select("listOfInputs.txInScript").collect
+    val txInScriptExpected: Array[Byte] = Array(0x04.toByte, 0xFF.toByte, 0xFF.toByte, 0x00.toByte, 0x1D.toByte, 0x01.toByte, 0x04.toByte, 0x45.toByte, 0x54.toByte, 0x68.toByte, 0x65.toByte, 0x20.toByte, 0x54.toByte, 0x69.toByte, 0x6D.toByte, 0x65.toByte,
+      0x73.toByte, 0x20.toByte, 0x30.toByte, 0x33.toByte, 0x2F.toByte, 0x4A.toByte, 0x61.toByte, 0x6E.toByte, 0x2F.toByte, 0x32.toByte, 0x30.toByte, 0x30.toByte, 0x39.toByte, 0x20.toByte, 0x43.toByte, 0x68.toByte,
+      0x61.toByte, 0x6E.toByte, 0x63.toByte, 0x65.toByte, 0x6C.toByte, 0x6C.toByte, 0x6F.toByte, 0x72.toByte, 0x20.toByte, 0x6F.toByte, 0x6E.toByte, 0x20.toByte, 0x62.toByte, 0x72.toByte, 0x69.toByte, 0x6E.toByte, 0x6B.toByte,
+      0x20.toByte, 0x6F.toByte, 0x66.toByte, 0x20.toByte, 0x73.toByte, 0x65.toByte, 0x63.toByte, 0x6F.toByte, 0x6E.toByte, 0x64.toByte, 0x20.toByte, 0x62.toByte, 0x61.toByte, 0x69.toByte, 0x6C.toByte, 0x6F.toByte,
+      0x75.toByte, 0x74.toByte, 0x20.toByte, 0x66.toByte, 0x6F.toByte, 0x72.toByte, 0x20.toByte, 0x62.toByte, 0x61.toByte, 0x6E.toByte, 0x6B.toByte, 0x73.toByte)
+    assert(txInScriptExpected.deep == txInScript(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val seqNo = transactionsLOIDF.select("listOfInputs.seqNo").collect
+    assert(4294967295L == seqNo(0).getLong(0))
+    val transactionsLOODF = transactionsDF.select(explode(transactionsDF("transactions.listOfOutputs")).alias("listOfOutputs"))
+    val value = transactionsLOODF.select("listOfOutputs.value").collect
+    assert(5000000000L == value(0).getLong(0))
+    val txOutScriptLength = transactionsLOODF.select("listOfOutputs.txOutScriptLength").collect
+    val txOutScriptLengthExpected: Array[Byte] = Array(0x43.toByte)
+    assert(txOutScriptLengthExpected.deep == txOutScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val txOutScript = transactionsLOODF.select("listOfOutputs.txOutScript").collect
+    val txOutScriptExpected: Array[Byte] = Array(0x41.toByte, 0x04.toByte, 0x67.toByte, 0x8A.toByte, 0xFD.toByte, 0xB0.toByte, 0xFE.toByte, 0x55.toByte, 0x48.toByte, 0x27.toByte, 0x19.toByte, 0x67.toByte, 0xF1.toByte, 0xA6.toByte, 0x71.toByte, 0x30.toByte,
+      0xB7.toByte, 0x10.toByte, 0x5C.toByte, 0xD6.toByte, 0xA8.toByte, 0x28.toByte, 0xE0.toByte, 0x39.toByte, 0x09.toByte, 0xA6.toByte, 0x79.toByte, 0x62.toByte, 0xE0.toByte, 0xEA.toByte, 0x1F.toByte, 0x61.toByte,
+      0xDE.toByte, 0xB6.toByte, 0x49.toByte, 0xF6.toByte, 0xBC.toByte, 0x3F.toByte, 0x4C.toByte, 0xEF.toByte, 0x38.toByte, 0xC4.toByte, 0xF3.toByte, 0x55.toByte, 0x04.toByte, 0xE5.toByte, 0x1E.toByte, 0xC1.toByte,
+      0x12.toByte, 0xDE.toByte, 0x5C.toByte, 0x38.toByte, 0x4D.toByte, 0xF7.toByte, 0xBA.toByte, 0x0B.toByte, 0x8D.toByte, 0x57.toByte, 0x8A.toByte, 0x4C.toByte, 0x70.toByte, 0x2B.toByte, 0x6B.toByte, 0xF1.toByte,
+      0x1D.toByte, 0x5F.toByte, 0xAC.toByte)
+    assert(txOutScriptExpected.deep == txOutScript(0).get(0).asInstanceOf[Array[Byte]].deep)
+  }
 
-"The genesis block on DFS" should "be fully read in dataframe" in {
-	Given("Genesis Block on DFSCluster")
-	// create input directory
-   dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
-	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
-	// copy bitcoin blocks
-	val classLoader = getClass.getClassLoader
-    	// put testdata on DFS
-    	val fileName: String="genesis.blk"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile
-    	val inputFile=new Path(fileNameFullLocal)
-    	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
-	When("reading Genesis block using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri.toString+DFS_INPUT_DIR_NAME)
-	Then("all fields should be readable trough Spark SQL")
-	// check first if structure is correct
-	assert("blockSize"==df.columns(0))
-	assert("magicNo"==df.columns(1))
-	assert("version"==df.columns(2))
-	assert("time"==df.columns(3))
-	assert("bits"==df.columns(4))
-	assert("nonce"==df.columns(5))
-	assert("transactionCounter"==df.columns(6))
-	assert("hashPrevBlock"==df.columns(7))
-	assert("hashMerkleRoot"==df.columns(8))
-	assert("transactions"==df.columns(9))
-	// validate block data
-	val blockSize = df.select("blockSize").collect
-	assert(285==blockSize(0).getInt(0))
-	val magicNo = df.select("magicNo").collect
-	val magicNoExpected : Array[Byte] = Array(0xF9.toByte,0xBE.toByte,0xB4.toByte,0xD9.toByte)
-	assert(magicNoExpected.deep==magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val version = df.select("version").collect
-	assert(1==version(0).getInt(0))
-	val time = df.select("time").collect
-	assert(1231006505==time(0).getInt(0))
-	val bits = df.select("bits").collect
-	val bitsExpected: Array[Byte] = Array(0xFF.toByte,0xFF.toByte,0x00.toByte,0x1D.toByte)
-	assert(bitsExpected.deep==bits(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val nonce = df.select("nonce").collect
-	assert(2083236893==nonce(0).getInt(0))
-	val transactionCounter = df.select("transactionCounter").collect
-	assert(1==transactionCounter(0).getLong(0))
-	val hashPrevBlock = df.select("hashPrevBlock").collect
-	val hashPrevBlockExpected: Array[Byte] = Array(0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte)
-	assert(hashPrevBlockExpected.deep==hashPrevBlock(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val hashMerkleRoot = df.select("hashMerkleRoot").collect
-	val hashMerkleRootExpected: Array[Byte] = Array(0x3B.toByte,0xA3.toByte,0xED.toByte,0xFD.toByte,0x7A.toByte,0x7B.toByte,0x12.toByte,0xB2.toByte,0x7A.toByte,0xC7.toByte,0x2C.toByte,0x3E.toByte,0x67.toByte,0x76.toByte,0x8F.toByte,0x61.toByte,0x7F.toByte,
-0xC8.toByte,0x1B.toByte,0xC3.toByte,0x88.toByte,0x8A.toByte,0x51.toByte,0x32.toByte,0x3A.toByte,0x9F.toByte,0xB8.toByte,0xAA.toByte,0x4B.toByte,0x1E.toByte,0x5E.toByte,0x4A.toByte)
-	assert(hashMerkleRootExpected.deep==hashMerkleRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
-	// validate transactions
-	val transactionsDF=df.select(explode(df("transactions")).alias("transactions"))
-	// one transaction
-	val transactionsDFCount = transactionsDF.count
-	assert(1==transactionsDFCount)
-	val transactionsVersion=transactionsDF.select("transactions.version").collect
-	assert(1==transactionsVersion(0).getInt(0))
-	val inCounter = transactionsDF.select("transactions.inCounter").collect
-	val inCounterExpected: Array[Byte] = Array(0x01.toByte)
-	assert(inCounterExpected.deep==inCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val outCounter = transactionsDF.select("transactions.outCounter").collect
-	val outCounterExpected: Array[Byte] = Array(0x01.toByte)
-	assert(outCounterExpected.deep==outCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val transactionsLockTime=transactionsDF.select("transactions.lockTime").collect
-	assert(0==transactionsLockTime(0).getInt(0))
-	val transactionsLOIDF = transactionsDF.select(explode(transactionsDF("transactions.listOfInputs")).alias("listOfInputs"))
-	val prevTransactionHash = transactionsLOIDF.select("listOfInputs.prevTransactionHash").collect
-	val prevTransactionHashExpected: Array[Byte] = Array(0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte)
-	assert(prevTransactionHashExpected.deep==prevTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val previousTxOutIndex = transactionsLOIDF.select("listOfInputs.previousTxOutIndex").collect
-	assert(4294967295L==previousTxOutIndex(0).getLong(0))
-	val txInScriptLength = transactionsLOIDF.select("listOfInputs.txInScriptLength").collect
-	val txInScriptLengthExpected: Array[Byte] = Array(0x4D.toByte)
-	assert(txInScriptLengthExpected.deep==txInScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val txInScript = transactionsLOIDF.select("listOfInputs.txInScript").collect
-	val txInScriptExpected: Array[Byte] =Array(0x04.toByte,0xFF.toByte,0xFF.toByte,0x00.toByte,0x1D.toByte,0x01.toByte,0x04.toByte,0x45.toByte,0x54.toByte,0x68.toByte,0x65.toByte,0x20.toByte,0x54.toByte,0x69.toByte,0x6D.toByte,0x65.toByte,
-0x73.toByte,0x20.toByte,0x30.toByte,0x33.toByte,0x2F.toByte,0x4A.toByte,0x61.toByte,0x6E.toByte,0x2F.toByte,0x32.toByte,0x30.toByte,0x30.toByte,0x39.toByte,0x20.toByte,0x43.toByte,0x68.toByte,
-0x61.toByte,0x6E.toByte,0x63.toByte,0x65.toByte,0x6C.toByte,0x6C.toByte,0x6F.toByte,0x72.toByte,0x20.toByte,0x6F.toByte,0x6E.toByte,0x20.toByte,0x62.toByte,0x72.toByte,0x69.toByte,0x6E.toByte,0x6B.toByte,
-0x20.toByte,0x6F.toByte,0x66.toByte,0x20.toByte,0x73.toByte,0x65.toByte,0x63.toByte,0x6F.toByte,0x6E.toByte,0x64.toByte,0x20.toByte,0x62.toByte,0x61.toByte,0x69.toByte,0x6C.toByte,0x6F.toByte,
-0x75.toByte,0x74.toByte,0x20.toByte,0x66.toByte,0x6F.toByte,0x72.toByte,0x20.toByte,0x62.toByte,0x61.toByte,0x6E.toByte,0x6B.toByte,0x73.toByte)
-	assert(txInScriptExpected.deep==txInScript(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val seqNo = transactionsLOIDF.select("listOfInputs.seqNo").collect
-	assert(4294967295L==seqNo(0).getLong(0))
-	val transactionsLOODF = transactionsDF.select(explode(transactionsDF("transactions.listOfOutputs")).alias("listOfOutputs"))
-	val value = transactionsLOODF.select("listOfOutputs.value").collect
-	assert(5000000000L==value(0).getLong(0))
-	val txOutScriptLength = transactionsLOODF.select("listOfOutputs.txOutScriptLength").collect
-	val txOutScriptLengthExpected: Array[Byte] = Array(0x43.toByte)
-	assert(txOutScriptLengthExpected.deep==txOutScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val txOutScript = transactionsLOODF.select("listOfOutputs.txOutScript").collect
-	val txOutScriptExpected: Array[Byte] = Array(0x41.toByte,0x04.toByte,0x67.toByte,0x8A.toByte,0xFD.toByte,0xB0.toByte,0xFE.toByte,0x55.toByte,0x48.toByte,0x27.toByte,0x19.toByte,0x67.toByte,0xF1.toByte,0xA6.toByte,0x71.toByte,0x30.toByte,
-0xB7.toByte,0x10.toByte,0x5C.toByte,0xD6.toByte,0xA8.toByte,0x28.toByte,0xE0.toByte,0x39.toByte,0x09.toByte,0xA6.toByte,0x79.toByte,0x62.toByte,0xE0.toByte,0xEA.toByte,0x1F.toByte,0x61.toByte,
-0xDE.toByte,0xB6.toByte,0x49.toByte,0xF6.toByte,0xBC.toByte,0x3F.toByte,0x4C.toByte,0xEF.toByte,0x38.toByte,0xC4.toByte,0xF3.toByte,0x55.toByte,0x04.toByte,0xE5.toByte,0x1E.toByte,0xC1.toByte,
-0x12.toByte,0xDE.toByte,0x5C.toByte,0x38.toByte,0x4D.toByte,0xF7.toByte,0xBA.toByte,0x0B.toByte,0x8D.toByte,0x57.toByte,0x8A.toByte,0x4C.toByte,0x70.toByte,0x2B.toByte,0x6B.toByte,0xF1.toByte,
-0x1D.toByte,0x5F.toByte,0xAC.toByte)
-	assert(txOutScriptExpected.deep==txOutScript(0).get(0).asInstanceOf[Array[Byte]].deep)
-}
+  "The genesis block on DFS" should "be fully read in dataframe with rich datatypes" in {
+    Given("Genesis Block on DFSCluster")
+    // create input directory
+    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR, true)
+    dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
+    // copy bitcoin blocks
+    val classLoader = getClass.getClassLoader
+    // put testdata on DFS
+    val fileName: String = "genesis.blk"
+    val fileNameFullLocal = classLoader.getResource("testdata/" + fileName).getFile
+    val inputFile = new Path(fileNameFullLocal)
+    dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
+    When("reading Genesis block using datasource")
+    val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri.toString + DFS_INPUT_DIR_NAME)
+    Then("all fields should be readable trough Spark SQL")
+    // check first if structure is correct
+    assert("blockSize" == df.columns(0))
+    assert("magicNo" == df.columns(1))
+    assert("version" == df.columns(2))
+    assert("time" == df.columns(3))
+    assert("bits" == df.columns(4))
+    assert("nonce" == df.columns(5))
+    assert("transactionCounter" == df.columns(6))
+    assert("hashPrevBlock" == df.columns(7))
+    assert("hashMerkleRoot" == df.columns(8))
+    assert("transactions" == df.columns(9))
+    // validate block data
+    val blockSize = df.select("blockSize").collect
+    assert(285 == blockSize(0).getInt(0))
+    val magicNo = df.select("magicNo").collect
+    val magicNoExpected: Array[Byte] = Array(0xF9.toByte, 0xBE.toByte, 0xB4.toByte, 0xD9.toByte)
+    assert(magicNoExpected.deep == magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val version = df.select("version").collect
+    assert(1 == version(0).getInt(0))
+    val time = df.select("time").collect
+    assert(1231006505 == time(0).getInt(0))
+    val bits = df.select("bits").collect
+    val bitsExpected: Array[Byte] = Array(0xFF.toByte, 0xFF.toByte, 0x00.toByte, 0x1D.toByte)
+    assert(bitsExpected.deep == bits(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val nonce = df.select("nonce").collect
+    assert(2083236893 == nonce(0).getInt(0))
+    val transactionCounter = df.select("transactionCounter").collect
+    assert(1 == transactionCounter(0).getLong(0))
+    val hashPrevBlock = df.select("hashPrevBlock").collect
+    val hashPrevBlockExpected: Array[Byte] = Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)
+    assert(hashPrevBlockExpected.deep == hashPrevBlock(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val hashMerkleRoot = df.select("hashMerkleRoot").collect
+    val hashMerkleRootExpected: Array[Byte] = Array(0x3B.toByte, 0xA3.toByte, 0xED.toByte, 0xFD.toByte, 0x7A.toByte, 0x7B.toByte, 0x12.toByte, 0xB2.toByte, 0x7A.toByte, 0xC7.toByte, 0x2C.toByte, 0x3E.toByte, 0x67.toByte, 0x76.toByte, 0x8F.toByte, 0x61.toByte, 0x7F.toByte,
+      0xC8.toByte, 0x1B.toByte, 0xC3.toByte, 0x88.toByte, 0x8A.toByte, 0x51.toByte, 0x32.toByte, 0x3A.toByte, 0x9F.toByte, 0xB8.toByte, 0xAA.toByte, 0x4B.toByte, 0x1E.toByte, 0x5E.toByte, 0x4A.toByte)
+    assert(hashMerkleRootExpected.deep == hashMerkleRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
+    // validate transactions
+    val transactionsDF = df.select(explode(df("transactions")).alias("transactions"))
+    // one transaction
+    val transactionsDFCount = transactionsDF.count
+    assert(1 == transactionsDFCount)
+    val transactionsVersion = transactionsDF.select("transactions.version").collect
+    assert(1 == transactionsVersion(0).getInt(0))
+    val inCounter = transactionsDF.select("transactions.inCounter").collect
+    val inCounterExpected: Array[Byte] = Array(0x01.toByte)
+    assert(inCounterExpected.deep == inCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val outCounter = transactionsDF.select("transactions.outCounter").collect
+    val outCounterExpected: Array[Byte] = Array(0x01.toByte)
+    assert(outCounterExpected.deep == outCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val transactionsLockTime = transactionsDF.select("transactions.lockTime").collect
+    assert(0 == transactionsLockTime(0).getInt(0))
+    val transactionsLOIDF = transactionsDF.select(explode(transactionsDF("transactions.listOfInputs")).alias("listOfInputs"))
+    val prevTransactionHash = transactionsLOIDF.select("listOfInputs.prevTransactionHash").collect
+    val prevTransactionHashExpected: Array[Byte] = Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)
+    assert(prevTransactionHashExpected.deep == prevTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val previousTxOutIndex = transactionsLOIDF.select("listOfInputs.previousTxOutIndex").collect
+    assert(4294967295L == previousTxOutIndex(0).getLong(0))
+    val txInScriptLength = transactionsLOIDF.select("listOfInputs.txInScriptLength").collect
+    val txInScriptLengthExpected: Array[Byte] = Array(0x4D.toByte)
+    assert(txInScriptLengthExpected.deep == txInScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val txInScript = transactionsLOIDF.select("listOfInputs.txInScript").collect
+    val txInScriptExpected: Array[Byte] = Array(0x04.toByte, 0xFF.toByte, 0xFF.toByte, 0x00.toByte, 0x1D.toByte, 0x01.toByte, 0x04.toByte, 0x45.toByte, 0x54.toByte, 0x68.toByte, 0x65.toByte, 0x20.toByte, 0x54.toByte, 0x69.toByte, 0x6D.toByte, 0x65.toByte,
+      0x73.toByte, 0x20.toByte, 0x30.toByte, 0x33.toByte, 0x2F.toByte, 0x4A.toByte, 0x61.toByte, 0x6E.toByte, 0x2F.toByte, 0x32.toByte, 0x30.toByte, 0x30.toByte, 0x39.toByte, 0x20.toByte, 0x43.toByte, 0x68.toByte,
+      0x61.toByte, 0x6E.toByte, 0x63.toByte, 0x65.toByte, 0x6C.toByte, 0x6C.toByte, 0x6F.toByte, 0x72.toByte, 0x20.toByte, 0x6F.toByte, 0x6E.toByte, 0x20.toByte, 0x62.toByte, 0x72.toByte, 0x69.toByte, 0x6E.toByte, 0x6B.toByte,
+      0x20.toByte, 0x6F.toByte, 0x66.toByte, 0x20.toByte, 0x73.toByte, 0x65.toByte, 0x63.toByte, 0x6F.toByte, 0x6E.toByte, 0x64.toByte, 0x20.toByte, 0x62.toByte, 0x61.toByte, 0x69.toByte, 0x6C.toByte, 0x6F.toByte,
+      0x75.toByte, 0x74.toByte, 0x20.toByte, 0x66.toByte, 0x6F.toByte, 0x72.toByte, 0x20.toByte, 0x62.toByte, 0x61.toByte, 0x6E.toByte, 0x6B.toByte, 0x73.toByte)
+    assert(txInScriptExpected.deep == txInScript(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val seqNo = transactionsLOIDF.select("listOfInputs.seqNo").collect
+    assert(4294967295L == seqNo(0).getLong(0))
+    val transactionsLOODF = transactionsDF.select(explode(transactionsDF("transactions.listOfOutputs")).alias("listOfOutputs"))
+    val value = transactionsLOODF.select("listOfOutputs.value").collect
+    assert(5000000000L == value(0).getLong(0))
+    val txOutScriptLength = transactionsLOODF.select("listOfOutputs.txOutScriptLength").collect
+    val txOutScriptLengthExpected: Array[Byte] = Array(0x43.toByte)
+    assert(txOutScriptLengthExpected.deep == txOutScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val txOutScript = transactionsLOODF.select("listOfOutputs.txOutScript").collect
+    val txOutScriptExpected: Array[Byte] = Array(0x41.toByte, 0x04.toByte, 0x67.toByte, 0x8A.toByte, 0xFD.toByte, 0xB0.toByte, 0xFE.toByte, 0x55.toByte, 0x48.toByte, 0x27.toByte, 0x19.toByte, 0x67.toByte, 0xF1.toByte, 0xA6.toByte, 0x71.toByte, 0x30.toByte,
+      0xB7.toByte, 0x10.toByte, 0x5C.toByte, 0xD6.toByte, 0xA8.toByte, 0x28.toByte, 0xE0.toByte, 0x39.toByte, 0x09.toByte, 0xA6.toByte, 0x79.toByte, 0x62.toByte, 0xE0.toByte, 0xEA.toByte, 0x1F.toByte, 0x61.toByte,
+      0xDE.toByte, 0xB6.toByte, 0x49.toByte, 0xF6.toByte, 0xBC.toByte, 0x3F.toByte, 0x4C.toByte, 0xEF.toByte, 0x38.toByte, 0xC4.toByte, 0xF3.toByte, 0x55.toByte, 0x04.toByte, 0xE5.toByte, 0x1E.toByte, 0xC1.toByte,
+      0x12.toByte, 0xDE.toByte, 0x5C.toByte, 0x38.toByte, 0x4D.toByte, 0xF7.toByte, 0xBA.toByte, 0x0B.toByte, 0x8D.toByte, 0x57.toByte, 0x8A.toByte, 0x4C.toByte, 0x70.toByte, 0x2B.toByte, 0x6B.toByte, 0xF1.toByte,
+      0x1D.toByte, 0x5F.toByte, 0xAC.toByte)
+    assert(txOutScriptExpected.deep == txOutScript(0).get(0).asInstanceOf[Array[Byte]].deep)
 
+    import df.sparkSession.implicits._
 
-"The genesis block on DFS" should "be fully read in dataframe with rich datatypes" in {
-	Given("Genesis Block on DFSCluster")
-	// create input directory
-   dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
-	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
-	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
-    	// put testdata on DFS
-    	val fileName: String="genesis.blk"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
-    	val inputFile=new Path(fileNameFullLocal)
-    	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
-	When("reading Genesis block using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
-	Then("all fields should be readable trough Spark SQL")
-	// check first if structure is correct
-	assert("blockSize"==df.columns(0))
-	assert("magicNo"==df.columns(1))
-	assert("version"==df.columns(2))
-	assert("time"==df.columns(3))
-	assert("bits"==df.columns(4))
-	assert("nonce"==df.columns(5))
-	assert("transactionCounter"==df.columns(6))
-	assert("hashPrevBlock"==df.columns(7))
-	assert("hashMerkleRoot"==df.columns(8))
-	assert("transactions"==df.columns(9))
-	// validate block data
-	val blockSize = df.select("blockSize").collect
-	assert(285==blockSize(0).getInt(0))
-	val magicNo = df.select("magicNo").collect
-	val magicNoExpected : Array[Byte] = Array(0xF9.toByte,0xBE.toByte,0xB4.toByte,0xD9.toByte)
-	assert(magicNoExpected.deep==magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val version = df.select("version").collect
-	assert(1==version(0).getInt(0))
-	val time = df.select("time").collect
-	assert(1231006505==time(0).getInt(0))
-	val bits = df.select("bits").collect
-	val bitsExpected: Array[Byte] = Array(0xFF.toByte,0xFF.toByte,0x00.toByte,0x1D.toByte)
-	assert(bitsExpected.deep==bits(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val nonce = df.select("nonce").collect
-	assert(2083236893==nonce(0).getInt(0))
-	val transactionCounter = df.select("transactionCounter").collect
-	assert(1==transactionCounter(0).getLong(0))
-	val hashPrevBlock = df.select("hashPrevBlock").collect
-	val hashPrevBlockExpected: Array[Byte] = Array(0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte)
-	assert(hashPrevBlockExpected.deep==hashPrevBlock(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val hashMerkleRoot = df.select("hashMerkleRoot").collect
-	val hashMerkleRootExpected: Array[Byte] = Array(0x3B.toByte,0xA3.toByte,0xED.toByte,0xFD.toByte,0x7A.toByte,0x7B.toByte,0x12.toByte,0xB2.toByte,0x7A.toByte,0xC7.toByte,0x2C.toByte,0x3E.toByte,0x67.toByte,0x76.toByte,0x8F.toByte,0x61.toByte,0x7F.toByte,
-0xC8.toByte,0x1B.toByte,0xC3.toByte,0x88.toByte,0x8A.toByte,0x51.toByte,0x32.toByte,0x3A.toByte,0x9F.toByte,0xB8.toByte,0xAA.toByte,0x4B.toByte,0x1E.toByte,0x5E.toByte,0x4A.toByte)
-	assert(hashMerkleRootExpected.deep==hashMerkleRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
-	// validate transactions
-	val transactionsDF=df.select(explode(df("transactions")).alias("transactions"))
-	// one transaction
-	val transactionsDFCount = transactionsDF.count
-	assert(1==transactionsDFCount)
-	val transactionsVersion=transactionsDF.select("transactions.version").collect
-	assert(1==transactionsVersion(0).getInt(0))
-	val inCounter = transactionsDF.select("transactions.inCounter").collect
-	val inCounterExpected: Array[Byte] = Array(0x01.toByte)
-	assert(inCounterExpected.deep==inCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val outCounter = transactionsDF.select("transactions.outCounter").collect
-	val outCounterExpected: Array[Byte] = Array(0x01.toByte)
-	assert(outCounterExpected.deep==outCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val transactionsLockTime=transactionsDF.select("transactions.lockTime").collect
-	assert(0==transactionsLockTime(0).getInt(0))
-	val transactionsLOIDF = transactionsDF.select(explode(transactionsDF("transactions.listOfInputs")).alias("listOfInputs"))
-	val prevTransactionHash = transactionsLOIDF.select("listOfInputs.prevTransactionHash").collect
-	val prevTransactionHashExpected: Array[Byte] = Array(0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte)
-	assert(prevTransactionHashExpected.deep==prevTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val previousTxOutIndex = transactionsLOIDF.select("listOfInputs.previousTxOutIndex").collect
-	assert(4294967295L==previousTxOutIndex(0).getLong(0))
-	val txInScriptLength = transactionsLOIDF.select("listOfInputs.txInScriptLength").collect
-	val txInScriptLengthExpected: Array[Byte] = Array(0x4D.toByte)
-	assert(txInScriptLengthExpected.deep==txInScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val txInScript = transactionsLOIDF.select("listOfInputs.txInScript").collect
-	val txInScriptExpected: Array[Byte] =Array(0x04.toByte,0xFF.toByte,0xFF.toByte,0x00.toByte,0x1D.toByte,0x01.toByte,0x04.toByte,0x45.toByte,0x54.toByte,0x68.toByte,0x65.toByte,0x20.toByte,0x54.toByte,0x69.toByte,0x6D.toByte,0x65.toByte,
-0x73.toByte,0x20.toByte,0x30.toByte,0x33.toByte,0x2F.toByte,0x4A.toByte,0x61.toByte,0x6E.toByte,0x2F.toByte,0x32.toByte,0x30.toByte,0x30.toByte,0x39.toByte,0x20.toByte,0x43.toByte,0x68.toByte,
-0x61.toByte,0x6E.toByte,0x63.toByte,0x65.toByte,0x6C.toByte,0x6C.toByte,0x6F.toByte,0x72.toByte,0x20.toByte,0x6F.toByte,0x6E.toByte,0x20.toByte,0x62.toByte,0x72.toByte,0x69.toByte,0x6E.toByte,0x6B.toByte,
-0x20.toByte,0x6F.toByte,0x66.toByte,0x20.toByte,0x73.toByte,0x65.toByte,0x63.toByte,0x6F.toByte,0x6E.toByte,0x64.toByte,0x20.toByte,0x62.toByte,0x61.toByte,0x69.toByte,0x6C.toByte,0x6F.toByte,
-0x75.toByte,0x74.toByte,0x20.toByte,0x66.toByte,0x6F.toByte,0x72.toByte,0x20.toByte,0x62.toByte,0x61.toByte,0x6E.toByte,0x6B.toByte,0x73.toByte)
-	assert(txInScriptExpected.deep==txInScript(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val seqNo = transactionsLOIDF.select("listOfInputs.seqNo").collect
-	assert(4294967295L==seqNo(0).getLong(0))
-	val transactionsLOODF = transactionsDF.select(explode(transactionsDF("transactions.listOfOutputs")).alias("listOfOutputs"))
-	val value = transactionsLOODF.select("listOfOutputs.value").collect
-	assert(5000000000L==value(0).getLong(0))
-	val txOutScriptLength = transactionsLOODF.select("listOfOutputs.txOutScriptLength").collect
-	val txOutScriptLengthExpected: Array[Byte] = Array(0x43.toByte)
-	assert(txOutScriptLengthExpected.deep==txOutScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val txOutScript = transactionsLOODF.select("listOfOutputs.txOutScript").collect
-	val txOutScriptExpected: Array[Byte] = Array(0x41.toByte,0x04.toByte,0x67.toByte,0x8A.toByte,0xFD.toByte,0xB0.toByte,0xFE.toByte,0x55.toByte,0x48.toByte,0x27.toByte,0x19.toByte,0x67.toByte,0xF1.toByte,0xA6.toByte,0x71.toByte,0x30.toByte,
-0xB7.toByte,0x10.toByte,0x5C.toByte,0xD6.toByte,0xA8.toByte,0x28.toByte,0xE0.toByte,0x39.toByte,0x09.toByte,0xA6.toByte,0x79.toByte,0x62.toByte,0xE0.toByte,0xEA.toByte,0x1F.toByte,0x61.toByte,
-0xDE.toByte,0xB6.toByte,0x49.toByte,0xF6.toByte,0xBC.toByte,0x3F.toByte,0x4C.toByte,0xEF.toByte,0x38.toByte,0xC4.toByte,0xF3.toByte,0x55.toByte,0x04.toByte,0xE5.toByte,0x1E.toByte,0xC1.toByte,
-0x12.toByte,0xDE.toByte,0x5C.toByte,0x38.toByte,0x4D.toByte,0xF7.toByte,0xBA.toByte,0x0B.toByte,0x8D.toByte,0x57.toByte,0x8A.toByte,0x4C.toByte,0x70.toByte,0x2B.toByte,0x6B.toByte,0xF1.toByte,
-0x1D.toByte,0x5F.toByte,0xAC.toByte)
-	assert(txOutScriptExpected.deep==txOutScript(0).get(0).asInstanceOf[Array[Byte]].deep)
-
-	import df.sparkSession.implicits._
-
- 	df.as[BitcoinBlock].collect()}
+    df.as[BitcoinBlock].collect()
+  }
 
   "The genesis block on DFS" should "be fully read in dataframe enriched with transactionHash" in {
     Given("Genesis Block on DFSCluster")
@@ -380,155 +379,155 @@ class SparkBitcoinBlockDSSparkMasterIntegrationSpec extends FlatSpec with Before
       0x7F.toByte, 0xC8.toByte, 0x1B.toByte, 0xC3.toByte, 0x88.toByte, 0x8A.toByte, 0x51.toByte, 0x32.toByte, 0x3A.toByte, 0x9F.toByte, 0xB8.toByte, 0xAA.toByte, 0x4B.toByte, 0x1E.toByte, 0x5E.toByte, 0x4A.toByte)
     assert(currentTransactionHashExpected.deep == currentTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
 
-	val transactionsVersion=transactionsDF.select("transactions.version").collect
-	assert(1==transactionsVersion(0).getInt(0))
-	val inCounter = transactionsDF.select("transactions.inCounter").collect
-	val inCounterExpected: Array[Byte] = Array(0x01.toByte)
-	assert(inCounterExpected.deep==inCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val outCounter = transactionsDF.select("transactions.outCounter").collect
-	val outCounterExpected: Array[Byte] = Array(0x01.toByte)
-	assert(outCounterExpected.deep==outCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val transactionsLockTime=transactionsDF.select("transactions.lockTime").collect
-	assert(0==transactionsLockTime(0).getInt(0))
-	val transactionsLOIDF = transactionsDF.select(explode(transactionsDF("transactions.listOfInputs")).alias("listOfInputs"))
-	val prevTransactionHash = transactionsLOIDF.select("listOfInputs.prevTransactionHash").collect
-	val prevTransactionHashExpected: Array[Byte] = Array(0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte)
-	assert(prevTransactionHashExpected.deep==prevTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val previousTxOutIndex = transactionsLOIDF.select("listOfInputs.previousTxOutIndex").collect
-	assert(4294967295L==previousTxOutIndex(0).getLong(0))
-	val txInScriptLength = transactionsLOIDF.select("listOfInputs.txInScriptLength").collect
-	val txInScriptLengthExpected: Array[Byte] = Array(0x4D.toByte)
-	assert(txInScriptLengthExpected.deep==txInScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val txInScript = transactionsLOIDF.select("listOfInputs.txInScript").collect
-	val txInScriptExpected: Array[Byte] =Array(0x04.toByte,0xFF.toByte,0xFF.toByte,0x00.toByte,0x1D.toByte,0x01.toByte,0x04.toByte,0x45.toByte,0x54.toByte,0x68.toByte,0x65.toByte,0x20.toByte,0x54.toByte,0x69.toByte,0x6D.toByte,0x65.toByte,
-0x73.toByte,0x20.toByte,0x30.toByte,0x33.toByte,0x2F.toByte,0x4A.toByte,0x61.toByte,0x6E.toByte,0x2F.toByte,0x32.toByte,0x30.toByte,0x30.toByte,0x39.toByte,0x20.toByte,0x43.toByte,0x68.toByte,
-0x61.toByte,0x6E.toByte,0x63.toByte,0x65.toByte,0x6C.toByte,0x6C.toByte,0x6F.toByte,0x72.toByte,0x20.toByte,0x6F.toByte,0x6E.toByte,0x20.toByte,0x62.toByte,0x72.toByte,0x69.toByte,0x6E.toByte,0x6B.toByte,
-0x20.toByte,0x6F.toByte,0x66.toByte,0x20.toByte,0x73.toByte,0x65.toByte,0x63.toByte,0x6F.toByte,0x6E.toByte,0x64.toByte,0x20.toByte,0x62.toByte,0x61.toByte,0x69.toByte,0x6C.toByte,0x6F.toByte,
-0x75.toByte,0x74.toByte,0x20.toByte,0x66.toByte,0x6F.toByte,0x72.toByte,0x20.toByte,0x62.toByte,0x61.toByte,0x6E.toByte,0x6B.toByte,0x73.toByte)
-	assert(txInScriptExpected.deep==txInScript(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val seqNo = transactionsLOIDF.select("listOfInputs.seqNo").collect
-	assert(4294967295L==seqNo(0).getLong(0))
-	val transactionsLOODF = transactionsDF.select(explode(transactionsDF("transactions.listOfOutputs")).alias("listOfOutputs"))
-	val value = transactionsLOODF.select("listOfOutputs.value").collect
-	assert(5000000000L==value(0).getLong(0))
-	val txOutScriptLength = transactionsLOODF.select("listOfOutputs.txOutScriptLength").collect
-	val txOutScriptLengthExpected: Array[Byte] = Array(0x43.toByte)
-	assert(txOutScriptLengthExpected.deep==txOutScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val txOutScript = transactionsLOODF.select("listOfOutputs.txOutScript").collect
-	val txOutScriptExpected: Array[Byte] = Array(0x41.toByte,0x04.toByte,0x67.toByte,0x8A.toByte,0xFD.toByte,0xB0.toByte,0xFE.toByte,0x55.toByte,0x48.toByte,0x27.toByte,0x19.toByte,0x67.toByte,0xF1.toByte,0xA6.toByte,0x71.toByte,0x30.toByte,
-0xB7.toByte,0x10.toByte,0x5C.toByte,0xD6.toByte,0xA8.toByte,0x28.toByte,0xE0.toByte,0x39.toByte,0x09.toByte,0xA6.toByte,0x79.toByte,0x62.toByte,0xE0.toByte,0xEA.toByte,0x1F.toByte,0x61.toByte,
-0xDE.toByte,0xB6.toByte,0x49.toByte,0xF6.toByte,0xBC.toByte,0x3F.toByte,0x4C.toByte,0xEF.toByte,0x38.toByte,0xC4.toByte,0xF3.toByte,0x55.toByte,0x04.toByte,0xE5.toByte,0x1E.toByte,0xC1.toByte,
-0x12.toByte,0xDE.toByte,0x5C.toByte,0x38.toByte,0x4D.toByte,0xF7.toByte,0xBA.toByte,0x0B.toByte,0x8D.toByte,0x57.toByte,0x8A.toByte,0x4C.toByte,0x70.toByte,0x2B.toByte,0x6B.toByte,0xF1.toByte,
-0x1D.toByte,0x5F.toByte,0xAC.toByte)
-	assert(txOutScriptExpected.deep==txOutScript(0).get(0).asInstanceOf[Array[Byte]].deep)
-}
+    val transactionsVersion = transactionsDF.select("transactions.version").collect
+    assert(1 == transactionsVersion(0).getInt(0))
+    val inCounter = transactionsDF.select("transactions.inCounter").collect
+    val inCounterExpected: Array[Byte] = Array(0x01.toByte)
+    assert(inCounterExpected.deep == inCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val outCounter = transactionsDF.select("transactions.outCounter").collect
+    val outCounterExpected: Array[Byte] = Array(0x01.toByte)
+    assert(outCounterExpected.deep == outCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val transactionsLockTime = transactionsDF.select("transactions.lockTime").collect
+    assert(0 == transactionsLockTime(0).getInt(0))
+    val transactionsLOIDF = transactionsDF.select(explode(transactionsDF("transactions.listOfInputs")).alias("listOfInputs"))
+    val prevTransactionHash = transactionsLOIDF.select("listOfInputs.prevTransactionHash").collect
+    val prevTransactionHashExpected: Array[Byte] = Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)
+    assert(prevTransactionHashExpected.deep == prevTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val previousTxOutIndex = transactionsLOIDF.select("listOfInputs.previousTxOutIndex").collect
+    assert(4294967295L == previousTxOutIndex(0).getLong(0))
+    val txInScriptLength = transactionsLOIDF.select("listOfInputs.txInScriptLength").collect
+    val txInScriptLengthExpected: Array[Byte] = Array(0x4D.toByte)
+    assert(txInScriptLengthExpected.deep == txInScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val txInScript = transactionsLOIDF.select("listOfInputs.txInScript").collect
+    val txInScriptExpected: Array[Byte] = Array(0x04.toByte, 0xFF.toByte, 0xFF.toByte, 0x00.toByte, 0x1D.toByte, 0x01.toByte, 0x04.toByte, 0x45.toByte, 0x54.toByte, 0x68.toByte, 0x65.toByte, 0x20.toByte, 0x54.toByte, 0x69.toByte, 0x6D.toByte, 0x65.toByte,
+      0x73.toByte, 0x20.toByte, 0x30.toByte, 0x33.toByte, 0x2F.toByte, 0x4A.toByte, 0x61.toByte, 0x6E.toByte, 0x2F.toByte, 0x32.toByte, 0x30.toByte, 0x30.toByte, 0x39.toByte, 0x20.toByte, 0x43.toByte, 0x68.toByte,
+      0x61.toByte, 0x6E.toByte, 0x63.toByte, 0x65.toByte, 0x6C.toByte, 0x6C.toByte, 0x6F.toByte, 0x72.toByte, 0x20.toByte, 0x6F.toByte, 0x6E.toByte, 0x20.toByte, 0x62.toByte, 0x72.toByte, 0x69.toByte, 0x6E.toByte, 0x6B.toByte,
+      0x20.toByte, 0x6F.toByte, 0x66.toByte, 0x20.toByte, 0x73.toByte, 0x65.toByte, 0x63.toByte, 0x6F.toByte, 0x6E.toByte, 0x64.toByte, 0x20.toByte, 0x62.toByte, 0x61.toByte, 0x69.toByte, 0x6C.toByte, 0x6F.toByte,
+      0x75.toByte, 0x74.toByte, 0x20.toByte, 0x66.toByte, 0x6F.toByte, 0x72.toByte, 0x20.toByte, 0x62.toByte, 0x61.toByte, 0x6E.toByte, 0x6B.toByte, 0x73.toByte)
+    assert(txInScriptExpected.deep == txInScript(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val seqNo = transactionsLOIDF.select("listOfInputs.seqNo").collect
+    assert(4294967295L == seqNo(0).getLong(0))
+    val transactionsLOODF = transactionsDF.select(explode(transactionsDF("transactions.listOfOutputs")).alias("listOfOutputs"))
+    val value = transactionsLOODF.select("listOfOutputs.value").collect
+    assert(5000000000L == value(0).getLong(0))
+    val txOutScriptLength = transactionsLOODF.select("listOfOutputs.txOutScriptLength").collect
+    val txOutScriptLengthExpected: Array[Byte] = Array(0x43.toByte)
+    assert(txOutScriptLengthExpected.deep == txOutScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val txOutScript = transactionsLOODF.select("listOfOutputs.txOutScript").collect
+    val txOutScriptExpected: Array[Byte] = Array(0x41.toByte, 0x04.toByte, 0x67.toByte, 0x8A.toByte, 0xFD.toByte, 0xB0.toByte, 0xFE.toByte, 0x55.toByte, 0x48.toByte, 0x27.toByte, 0x19.toByte, 0x67.toByte, 0xF1.toByte, 0xA6.toByte, 0x71.toByte, 0x30.toByte,
+      0xB7.toByte, 0x10.toByte, 0x5C.toByte, 0xD6.toByte, 0xA8.toByte, 0x28.toByte, 0xE0.toByte, 0x39.toByte, 0x09.toByte, 0xA6.toByte, 0x79.toByte, 0x62.toByte, 0xE0.toByte, 0xEA.toByte, 0x1F.toByte, 0x61.toByte,
+      0xDE.toByte, 0xB6.toByte, 0x49.toByte, 0xF6.toByte, 0xBC.toByte, 0x3F.toByte, 0x4C.toByte, 0xEF.toByte, 0x38.toByte, 0xC4.toByte, 0xF3.toByte, 0x55.toByte, 0x04.toByte, 0xE5.toByte, 0x1E.toByte, 0xC1.toByte,
+      0x12.toByte, 0xDE.toByte, 0x5C.toByte, 0x38.toByte, 0x4D.toByte, 0xF7.toByte, 0xBA.toByte, 0x0B.toByte, 0x8D.toByte, 0x57.toByte, 0x8A.toByte, 0x4C.toByte, 0x70.toByte, 0x2B.toByte, 0x6B.toByte, 0xF1.toByte,
+      0x1D.toByte, 0x5F.toByte, 0xAC.toByte)
+    assert(txOutScriptExpected.deep == txOutScript(0).get(0).asInstanceOf[Array[Byte]].deep)
+  }
 
+  "The genesis block on DFS" should "be fully read in dataframe enriched with transactionHash (rich datatypes)" in {
+    Given("Genesis Block on DFSCluster")
+    // create input directory
+    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR, true)
+    dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
+    // copy bitcoin blocks
+    val classLoader = getClass.getClassLoader
+    // put testdata on DFS
+    val fileName: String = "genesis.blk"
+    val fileNameFullLocal = classLoader.getResource("testdata/" + fileName).getFile
+    val inputFile = new Path(fileNameFullLocal)
+    dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
+    When("reading Genesis block using datasource")
+    val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").option("enrich", "true").load(dfsCluster.getFileSystem().getUri.toString + DFS_INPUT_DIR_NAME)
+    Then("all fields should be readable trough Spark SQL")
+    // check first if structure is correct
+    assert("blockSize" == df.columns(0))
+    assert("magicNo" == df.columns(1))
+    assert("version" == df.columns(2))
+    assert("time" == df.columns(3))
+    assert("bits" == df.columns(4))
+    assert("nonce" == df.columns(5))
+    assert("transactionCounter" == df.columns(6))
+    assert("hashPrevBlock" == df.columns(7))
+    assert("hashMerkleRoot" == df.columns(8))
+    assert("transactions" == df.columns(9))
+    // validate block data
+    val blockSize = df.select("blockSize").collect
+    assert(285 == blockSize(0).getInt(0))
+    val magicNo = df.select("magicNo").collect
+    val magicNoExpected: Array[Byte] = Array(0xF9.toByte, 0xBE.toByte, 0xB4.toByte, 0xD9.toByte)
+    assert(magicNoExpected.deep == magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val version = df.select("version").collect
+    assert(1 == version(0).getInt(0))
+    val time = df.select("time").collect
+    assert(1231006505 == time(0).getInt(0))
+    val bits = df.select("bits").collect
+    val bitsExpected: Array[Byte] = Array(0xFF.toByte, 0xFF.toByte, 0x00.toByte, 0x1D.toByte)
+    assert(bitsExpected.deep == bits(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val nonce = df.select("nonce").collect
+    assert(2083236893 == nonce(0).getInt(0))
+    val transactionCounter = df.select("transactionCounter").collect
+    assert(1 == transactionCounter(0).getLong(0))
+    val hashPrevBlock = df.select("hashPrevBlock").collect
+    val hashPrevBlockExpected: Array[Byte] = Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)
+    assert(hashPrevBlockExpected.deep == hashPrevBlock(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val hashMerkleRoot = df.select("hashMerkleRoot").collect
+    val hashMerkleRootExpected: Array[Byte] = Array(0x3B.toByte, 0xA3.toByte, 0xED.toByte, 0xFD.toByte, 0x7A.toByte, 0x7B.toByte, 0x12.toByte, 0xB2.toByte, 0x7A.toByte, 0xC7.toByte, 0x2C.toByte, 0x3E.toByte, 0x67.toByte, 0x76.toByte, 0x8F.toByte, 0x61.toByte, 0x7F.toByte,
+      0xC8.toByte, 0x1B.toByte, 0xC3.toByte, 0x88.toByte, 0x8A.toByte, 0x51.toByte, 0x32.toByte, 0x3A.toByte, 0x9F.toByte, 0xB8.toByte, 0xAA.toByte, 0x4B.toByte, 0x1E.toByte, 0x5E.toByte, 0x4A.toByte)
+    assert(hashMerkleRootExpected.deep == hashMerkleRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
+    // validate transactions
+    val transactionsDF = df.select(explode(df("transactions")).alias("transactions"))
+    // one transaction
+    val transactionsDFCount = transactionsDF.count
+    assert(1 == transactionsDFCount)
+    val currentTransactionHash = transactionsDF.select("transactions.currentTransactionHash").collect
+    val currentTransactionHashExpected: Array[Byte] = Array(0x3B.toByte, 0xA3.toByte, 0xED.toByte, 0xFD.toByte, 0x7A.toByte, 0x7B.toByte, 0x12.toByte, 0xB2.toByte, 0x7A.toByte, 0xC7.toByte, 0x2C.toByte, 0x3E.toByte, 0x67.toByte, 0x76.toByte, 0x8F.toByte, 0x61.toByte,
+      0x7F.toByte, 0xC8.toByte, 0x1B.toByte, 0xC3.toByte, 0x88.toByte, 0x8A.toByte, 0x51.toByte, 0x32.toByte, 0x3A.toByte, 0x9F.toByte, 0xB8.toByte, 0xAA.toByte, 0x4B.toByte, 0x1E.toByte, 0x5E.toByte, 0x4A.toByte)
+    assert(currentTransactionHashExpected.deep == currentTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
 
-"The genesis block on DFS" should "be fully read in dataframe enriched with transactionHash (rich datatypes)" in {
-	Given("Genesis Block on DFSCluster")
-	// create input directory
-   dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
-	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
-	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
-    	// put testdata on DFS
-    	val fileName: String="genesis.blk"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
-    	val inputFile=new Path(fileNameFullLocal)
-    	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
-	When("reading Genesis block using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").option("enrich","true").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
-	Then("all fields should be readable trough Spark SQL")
-	// check first if structure is correct
-	assert("blockSize"==df.columns(0))
-	assert("magicNo"==df.columns(1))
-	assert("version"==df.columns(2))
-	assert("time"==df.columns(3))
-	assert("bits"==df.columns(4))
-	assert("nonce"==df.columns(5))
-	assert("transactionCounter"==df.columns(6))
-	assert("hashPrevBlock"==df.columns(7))
-	assert("hashMerkleRoot"==df.columns(8))
-	assert("transactions"==df.columns(9))
-	// validate block data
-	val blockSize = df.select("blockSize").collect
-	assert(285==blockSize(0).getInt(0))
-	val magicNo = df.select("magicNo").collect
-	val magicNoExpected : Array[Byte] = Array(0xF9.toByte,0xBE.toByte,0xB4.toByte,0xD9.toByte)
-	assert(magicNoExpected.deep==magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val version = df.select("version").collect
-	assert(1==version(0).getInt(0))
-	val time = df.select("time").collect
-	assert(1231006505==time(0).getInt(0))
-	val bits = df.select("bits").collect
-	val bitsExpected: Array[Byte] = Array(0xFF.toByte,0xFF.toByte,0x00.toByte,0x1D.toByte)
-	assert(bitsExpected.deep==bits(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val nonce = df.select("nonce").collect
-	assert(2083236893==nonce(0).getInt(0))
-	val transactionCounter = df.select("transactionCounter").collect
-	assert(1==transactionCounter(0).getLong(0))
-	val hashPrevBlock = df.select("hashPrevBlock").collect
-	val hashPrevBlockExpected: Array[Byte] = Array(0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte)
-	assert(hashPrevBlockExpected.deep==hashPrevBlock(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val hashMerkleRoot = df.select("hashMerkleRoot").collect
-	val hashMerkleRootExpected: Array[Byte] = Array(0x3B.toByte,0xA3.toByte,0xED.toByte,0xFD.toByte,0x7A.toByte,0x7B.toByte,0x12.toByte,0xB2.toByte,0x7A.toByte,0xC7.toByte,0x2C.toByte,0x3E.toByte,0x67.toByte,0x76.toByte,0x8F.toByte,0x61.toByte,0x7F.toByte,
-0xC8.toByte,0x1B.toByte,0xC3.toByte,0x88.toByte,0x8A.toByte,0x51.toByte,0x32.toByte,0x3A.toByte,0x9F.toByte,0xB8.toByte,0xAA.toByte,0x4B.toByte,0x1E.toByte,0x5E.toByte,0x4A.toByte)
-	assert(hashMerkleRootExpected.deep==hashMerkleRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
-	// validate transactions
-	val transactionsDF=df.select(explode(df("transactions")).alias("transactions"))
-	// one transaction
-	val transactionsDFCount = transactionsDF.count
-	assert(1==transactionsDFCount)
-  val currentTransactionHash = transactionsDF.select("transactions.currentTransactionHash").collect
-	val currentTransactionHashExpected : Array[Byte] = Array(0x3B.toByte,0xA3.toByte,0xED.toByte,0xFD.toByte,0x7A.toByte,0x7B.toByte,0x12.toByte,0xB2.toByte,0x7A.toByte,0xC7.toByte,0x2C.toByte,0x3E.toByte,0x67.toByte,0x76.toByte,0x8F.toByte,0x61.toByte,
-0x7F.toByte,0xC8.toByte,0x1B.toByte,0xC3.toByte,0x88.toByte,0x8A.toByte,0x51.toByte,0x32.toByte,0x3A.toByte,0x9F.toByte,0xB8.toByte,0xAA.toByte,0x4B.toByte,0x1E.toByte,0x5E.toByte,0x4A.toByte)
-	assert(currentTransactionHashExpected.deep==currentTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val transactionsVersion = transactionsDF.select("transactions.version").collect
+    assert(1 == transactionsVersion(0).getInt(0))
+    val inCounter = transactionsDF.select("transactions.inCounter").collect
+    val inCounterExpected: Array[Byte] = Array(0x01.toByte)
+    assert(inCounterExpected.deep == inCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val outCounter = transactionsDF.select("transactions.outCounter").collect
+    val outCounterExpected: Array[Byte] = Array(0x01.toByte)
+    assert(outCounterExpected.deep == outCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val transactionsLockTime = transactionsDF.select("transactions.lockTime").collect
+    assert(0 == transactionsLockTime(0).getInt(0))
+    val transactionsLOIDF = transactionsDF.select(explode(transactionsDF("transactions.listOfInputs")).alias("listOfInputs"))
+    val prevTransactionHash = transactionsLOIDF.select("listOfInputs.prevTransactionHash").collect
+    val prevTransactionHashExpected: Array[Byte] = Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)
+    assert(prevTransactionHashExpected.deep == prevTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val previousTxOutIndex = transactionsLOIDF.select("listOfInputs.previousTxOutIndex").collect
+    assert(4294967295L == previousTxOutIndex(0).getLong(0))
+    val txInScriptLength = transactionsLOIDF.select("listOfInputs.txInScriptLength").collect
+    val txInScriptLengthExpected: Array[Byte] = Array(0x4D.toByte)
+    assert(txInScriptLengthExpected.deep == txInScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val txInScript = transactionsLOIDF.select("listOfInputs.txInScript").collect
+    val txInScriptExpected: Array[Byte] = Array(0x04.toByte, 0xFF.toByte, 0xFF.toByte, 0x00.toByte, 0x1D.toByte, 0x01.toByte, 0x04.toByte, 0x45.toByte, 0x54.toByte, 0x68.toByte, 0x65.toByte, 0x20.toByte, 0x54.toByte, 0x69.toByte, 0x6D.toByte, 0x65.toByte,
+      0x73.toByte, 0x20.toByte, 0x30.toByte, 0x33.toByte, 0x2F.toByte, 0x4A.toByte, 0x61.toByte, 0x6E.toByte, 0x2F.toByte, 0x32.toByte, 0x30.toByte, 0x30.toByte, 0x39.toByte, 0x20.toByte, 0x43.toByte, 0x68.toByte,
+      0x61.toByte, 0x6E.toByte, 0x63.toByte, 0x65.toByte, 0x6C.toByte, 0x6C.toByte, 0x6F.toByte, 0x72.toByte, 0x20.toByte, 0x6F.toByte, 0x6E.toByte, 0x20.toByte, 0x62.toByte, 0x72.toByte, 0x69.toByte, 0x6E.toByte, 0x6B.toByte,
+      0x20.toByte, 0x6F.toByte, 0x66.toByte, 0x20.toByte, 0x73.toByte, 0x65.toByte, 0x63.toByte, 0x6F.toByte, 0x6E.toByte, 0x64.toByte, 0x20.toByte, 0x62.toByte, 0x61.toByte, 0x69.toByte, 0x6C.toByte, 0x6F.toByte,
+      0x75.toByte, 0x74.toByte, 0x20.toByte, 0x66.toByte, 0x6F.toByte, 0x72.toByte, 0x20.toByte, 0x62.toByte, 0x61.toByte, 0x6E.toByte, 0x6B.toByte, 0x73.toByte)
+    assert(txInScriptExpected.deep == txInScript(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val seqNo = transactionsLOIDF.select("listOfInputs.seqNo").collect
+    assert(4294967295L == seqNo(0).getLong(0))
+    val transactionsLOODF = transactionsDF.select(explode(transactionsDF("transactions.listOfOutputs")).alias("listOfOutputs"))
+    val value = transactionsLOODF.select("listOfOutputs.value").collect
+    assert(5000000000L == value(0).getLong(0))
+    val txOutScriptLength = transactionsLOODF.select("listOfOutputs.txOutScriptLength").collect
+    val txOutScriptLengthExpected: Array[Byte] = Array(0x43.toByte)
+    assert(txOutScriptLengthExpected.deep == txOutScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val txOutScript = transactionsLOODF.select("listOfOutputs.txOutScript").collect
+    val txOutScriptExpected: Array[Byte] = Array(0x41.toByte, 0x04.toByte, 0x67.toByte, 0x8A.toByte, 0xFD.toByte, 0xB0.toByte, 0xFE.toByte, 0x55.toByte, 0x48.toByte, 0x27.toByte, 0x19.toByte, 0x67.toByte, 0xF1.toByte, 0xA6.toByte, 0x71.toByte, 0x30.toByte,
+      0xB7.toByte, 0x10.toByte, 0x5C.toByte, 0xD6.toByte, 0xA8.toByte, 0x28.toByte, 0xE0.toByte, 0x39.toByte, 0x09.toByte, 0xA6.toByte, 0x79.toByte, 0x62.toByte, 0xE0.toByte, 0xEA.toByte, 0x1F.toByte, 0x61.toByte,
+      0xDE.toByte, 0xB6.toByte, 0x49.toByte, 0xF6.toByte, 0xBC.toByte, 0x3F.toByte, 0x4C.toByte, 0xEF.toByte, 0x38.toByte, 0xC4.toByte, 0xF3.toByte, 0x55.toByte, 0x04.toByte, 0xE5.toByte, 0x1E.toByte, 0xC1.toByte,
+      0x12.toByte, 0xDE.toByte, 0x5C.toByte, 0x38.toByte, 0x4D.toByte, 0xF7.toByte, 0xBA.toByte, 0x0B.toByte, 0x8D.toByte, 0x57.toByte, 0x8A.toByte, 0x4C.toByte, 0x70.toByte, 0x2B.toByte, 0x6B.toByte, 0xF1.toByte,
+      0x1D.toByte, 0x5F.toByte, 0xAC.toByte)
+    assert(txOutScriptExpected.deep == txOutScript(0).get(0).asInstanceOf[Array[Byte]].deep)
 
-	val transactionsVersion=transactionsDF.select("transactions.version").collect
-	assert(1==transactionsVersion(0).getInt(0))
-	val inCounter = transactionsDF.select("transactions.inCounter").collect
-	val inCounterExpected: Array[Byte] = Array(0x01.toByte)
-	assert(inCounterExpected.deep==inCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val outCounter = transactionsDF.select("transactions.outCounter").collect
-	val outCounterExpected: Array[Byte] = Array(0x01.toByte)
-	assert(outCounterExpected.deep==outCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val transactionsLockTime=transactionsDF.select("transactions.lockTime").collect
-	assert(0==transactionsLockTime(0).getInt(0))
-	val transactionsLOIDF = transactionsDF.select(explode(transactionsDF("transactions.listOfInputs")).alias("listOfInputs"))
-	val prevTransactionHash = transactionsLOIDF.select("listOfInputs.prevTransactionHash").collect
-	val prevTransactionHashExpected: Array[Byte] = Array(0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte)
-	assert(prevTransactionHashExpected.deep==prevTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val previousTxOutIndex = transactionsLOIDF.select("listOfInputs.previousTxOutIndex").collect
-	assert(4294967295L==previousTxOutIndex(0).getLong(0))
-	val txInScriptLength = transactionsLOIDF.select("listOfInputs.txInScriptLength").collect
-	val txInScriptLengthExpected: Array[Byte] = Array(0x4D.toByte)
-	assert(txInScriptLengthExpected.deep==txInScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val txInScript = transactionsLOIDF.select("listOfInputs.txInScript").collect
-	val txInScriptExpected: Array[Byte] =Array(0x04.toByte,0xFF.toByte,0xFF.toByte,0x00.toByte,0x1D.toByte,0x01.toByte,0x04.toByte,0x45.toByte,0x54.toByte,0x68.toByte,0x65.toByte,0x20.toByte,0x54.toByte,0x69.toByte,0x6D.toByte,0x65.toByte,
-0x73.toByte,0x20.toByte,0x30.toByte,0x33.toByte,0x2F.toByte,0x4A.toByte,0x61.toByte,0x6E.toByte,0x2F.toByte,0x32.toByte,0x30.toByte,0x30.toByte,0x39.toByte,0x20.toByte,0x43.toByte,0x68.toByte,
-0x61.toByte,0x6E.toByte,0x63.toByte,0x65.toByte,0x6C.toByte,0x6C.toByte,0x6F.toByte,0x72.toByte,0x20.toByte,0x6F.toByte,0x6E.toByte,0x20.toByte,0x62.toByte,0x72.toByte,0x69.toByte,0x6E.toByte,0x6B.toByte,
-0x20.toByte,0x6F.toByte,0x66.toByte,0x20.toByte,0x73.toByte,0x65.toByte,0x63.toByte,0x6F.toByte,0x6E.toByte,0x64.toByte,0x20.toByte,0x62.toByte,0x61.toByte,0x69.toByte,0x6C.toByte,0x6F.toByte,
-0x75.toByte,0x74.toByte,0x20.toByte,0x66.toByte,0x6F.toByte,0x72.toByte,0x20.toByte,0x62.toByte,0x61.toByte,0x6E.toByte,0x6B.toByte,0x73.toByte)
-	assert(txInScriptExpected.deep==txInScript(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val seqNo = transactionsLOIDF.select("listOfInputs.seqNo").collect
-	assert(4294967295L==seqNo(0).getLong(0))
-	val transactionsLOODF = transactionsDF.select(explode(transactionsDF("transactions.listOfOutputs")).alias("listOfOutputs"))
-	val value = transactionsLOODF.select("listOfOutputs.value").collect
-	assert(5000000000L==value(0).getLong(0))
-	val txOutScriptLength = transactionsLOODF.select("listOfOutputs.txOutScriptLength").collect
-	val txOutScriptLengthExpected: Array[Byte] = Array(0x43.toByte)
-	assert(txOutScriptLengthExpected.deep==txOutScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val txOutScript = transactionsLOODF.select("listOfOutputs.txOutScript").collect
-	val txOutScriptExpected: Array[Byte] = Array(0x41.toByte,0x04.toByte,0x67.toByte,0x8A.toByte,0xFD.toByte,0xB0.toByte,0xFE.toByte,0x55.toByte,0x48.toByte,0x27.toByte,0x19.toByte,0x67.toByte,0xF1.toByte,0xA6.toByte,0x71.toByte,0x30.toByte,
-0xB7.toByte,0x10.toByte,0x5C.toByte,0xD6.toByte,0xA8.toByte,0x28.toByte,0xE0.toByte,0x39.toByte,0x09.toByte,0xA6.toByte,0x79.toByte,0x62.toByte,0xE0.toByte,0xEA.toByte,0x1F.toByte,0x61.toByte,
-0xDE.toByte,0xB6.toByte,0x49.toByte,0xF6.toByte,0xBC.toByte,0x3F.toByte,0x4C.toByte,0xEF.toByte,0x38.toByte,0xC4.toByte,0xF3.toByte,0x55.toByte,0x04.toByte,0xE5.toByte,0x1E.toByte,0xC1.toByte,
-0x12.toByte,0xDE.toByte,0x5C.toByte,0x38.toByte,0x4D.toByte,0xF7.toByte,0xBA.toByte,0x0B.toByte,0x8D.toByte,0x57.toByte,0x8A.toByte,0x4C.toByte,0x70.toByte,0x2B.toByte,0x6B.toByte,0xF1.toByte,
-0x1D.toByte,0x5F.toByte,0xAC.toByte)
-	assert(txOutScriptExpected.deep==txOutScript(0).get(0).asInstanceOf[Array[Byte]].deep)
+    import df.sparkSession.implicits._
 
-	import df.sparkSession.implicits._
-
- 	df.as[EnrichedBitcoinBlock].collect()}
+    df.as[EnrichedBitcoinBlock].collect()
+  }
 
   "The scriptwitness block on DFS" should "be read in dataframe" in {
     Given("Scriptwitness Block on DFSCluster")
@@ -690,87 +689,84 @@ class SparkBitcoinBlockDSSparkMasterIntegrationSpec extends FlatSpec with Before
     // validate transactions
     val transactionsDF = df.select(explode(df("transactions")).alias("transactions"))
 
-	val transactionsDFCount = transactionsDF.count
-	assert(7==transactionsDFCount)
+    val transactionsDFCount = transactionsDF.count
+    assert(7 == transactionsDFCount)
+  }
 
-}
+  "The Namecoin block on DFS with AuxPOW information" should "be read in dataframe (with rich data types)" in {
+    Given("Namecoin Block on DFSCluster")
+    // create input directory
+    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR, true)
+    dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
+    // copy bitcoin blocks
+    val classLoader = getClass.getClassLoader
+    // put testdata on DFS
+    val fileName: String = "namecointhreedifferentopinoneblock.blk"
+    val fileNameFullLocal = classLoader.getResource("testdata/" + fileName).getFile
+    val inputFile = new Path(fileNameFullLocal)
+    dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
+    When("reading scriptwitness block using datasource")
+    val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4FE").option("readAuxPOW", "true").load(dfsCluster.getFileSystem().getUri.toString + DFS_INPUT_DIR_NAME)
+    Then("schema should be correct and number of transactions")
 
+    // check first if structure is correct
+    assert("blockSize" == df.columns(0))
+    assert("magicNo" == df.columns(1))
+    assert("version" == df.columns(2))
+    assert("time" == df.columns(3))
+    assert("bits" == df.columns(4))
+    assert("nonce" == df.columns(5))
+    assert("transactionCounter" == df.columns(6))
+    assert("hashPrevBlock" == df.columns(7))
+    assert("hashMerkleRoot" == df.columns(8))
+    assert("transactions" == df.columns(9))
+    assert("auxPOW" == df.columns(10))
+    // validate block data
+    val blockSize = df.select("blockSize").collect
+    assert(3125 == blockSize(0).getInt(0))
+    val magicNo = df.select("magicNo").collect
+    val magicNoExpected: Array[Byte] = Array(0xF9.toByte, 0xBE.toByte, 0xB4.toByte, 0xFE.toByte)
+    assert(magicNoExpected.deep == magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val version = df.select("version").collect
+    assert(65796 == version(0).getInt(0))
+    val time = df.select("time").collect
+    assert(1506767051 == time(0).getInt(0))
+    val bits = df.select("bits").collect
+    val bitsExpected: Array[Byte] = Array(0x71.toByte, 0x63.toByte, 0x01.toByte, 0x18.toByte)
+    assert(bitsExpected.deep == bits(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val nonce = df.select("nonce").collect
+    assert(0 == nonce(0).getInt(0))
+    val transactionCounter = df.select("transactionCounter").collect
+    assert(7 == transactionCounter(0).getLong(0))
+    // validate transactions
+    val transactionsDF = df.select(explode(df("transactions")).alias("transactions"))
 
-"The Namecoin block on DFS with AuxPOW information" should "be read in dataframe (with rich data types)" in {
-	Given("Namecoin Block on DFSCluster")
-	// create input directory
-   dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
-	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
-	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
-    	// put testdata on DFS
-    	val fileName: String="namecointhreedifferentopinoneblock.blk"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
-    	val inputFile=new Path(fileNameFullLocal)
-    	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
-	When("reading scriptwitness block using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4FE").option("readAuxPOW","true").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
-	Then("schema should be correct and number of transactions")
+    val transactionsDFCount = transactionsDF.count
+    assert(7 == transactionsDFCount)
 
-	// check first if structure is correct
-	assert("blockSize"==df.columns(0))
-	assert("magicNo"==df.columns(1))
-	assert("version"==df.columns(2))
-	assert("time"==df.columns(3))
-	assert("bits"==df.columns(4))
-	assert("nonce"==df.columns(5))
-	assert("transactionCounter"==df.columns(6))
-	assert("hashPrevBlock"==df.columns(7))
-	assert("hashMerkleRoot"==df.columns(8))
-	assert("transactions"==df.columns(9))
-  	assert("auxPOW"==df.columns(10))
-	// validate block data
-	val blockSize = df.select("blockSize").collect
-	assert(3125==blockSize(0).getInt(0))
-	val magicNo = df.select("magicNo").collect
-	val magicNoExpected : Array[Byte] = Array(0xF9.toByte,0xBE.toByte,0xB4.toByte,0xFE.toByte)
-	assert(magicNoExpected.deep==magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val version = df.select("version").collect
-	assert(65796==version(0).getInt(0))
-	val time = df.select("time").collect
-	assert(1506767051==time(0).getInt(0))
-	val bits = df.select("bits").collect
-	val bitsExpected: Array[Byte] = Array(0x71.toByte,0x63.toByte,0x01.toByte,0x18.toByte)
-	assert(bitsExpected.deep==bits(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val nonce = df.select("nonce").collect
-	assert(0==nonce(0).getInt(0))
-	val transactionCounter = df.select("transactionCounter").collect
-	assert(7==transactionCounter(0).getLong(0))
-		// validate transactions
-	val transactionsDF=df.select(explode(df("transactions")).alias("transactions"))
+    import df.sparkSession.implicits._
 
-	val transactionsDFCount = transactionsDF.count
-	assert(7==transactionsDFCount)
+    df.as[BitcoinBlockWithAuxPOW].collect()
+  }
 
-	import df.sparkSession.implicits._
+  "The Namecoin block on DFS with AuxPOW information" should "be read in dataframe with enrichment (incomplete test) with rich datatypes" in {
+    Given("Namecoin Block on DFSCluster")
+    // create input directory
+    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR, true)
+    dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
+    // copy bitcoin blocks
+    val classLoader = getClass.getClassLoader
+    // put testdata on DFS
+    val fileName: String = "namecointhreedifferentopinoneblock.blk"
+    val fileNameFullLocal = classLoader.getResource("testdata/" + fileName).getFile
+    val inputFile = new Path(fileNameFullLocal)
+    dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
+    When("reading scriptwitness block using datasource")
+    val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4FE").option("readAuxPOW", "true").option("enrich", "true").load(dfsCluster.getFileSystem().getUri.toString + DFS_INPUT_DIR_NAME)
+    Then("should be able to collect as dataset")
 
- 	df.as[BitcoinBlockWithAuxPOW].collect()
-}
+    import df.sparkSession.implicits._
 
-
-"The Namecoin block on DFS with AuxPOW information" should "be read in dataframe with enrichment (incomplete test) with rich datatypes" in {
-	Given("Namecoin Block on DFSCluster")
-	// create input directory
-   dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
-	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
-	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
-    	// put testdata on DFS
-    	val fileName: String="namecointhreedifferentopinoneblock.blk"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
-    	val inputFile=new Path(fileNameFullLocal)
-    	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
-	When("reading scriptwitness block using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4FE").option("readAuxPOW","true").option("enrich","true").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
-	Then("should be able to collect as dataset")
-
-	import df.sparkSession.implicits._
-
- 	df.as[EnrichedBitcoinBlockWithAuxPOW].collect()
-}
+    df.as[EnrichedBitcoinBlockWithAuxPOW].collect()
+  }
 }

--- a/src/it/scala/org/zuinnote/spark/bitcoin/block/SparkBitcoinBlockDSSparkMasterIntegrationSpec.scala
+++ b/src/it/scala/org/zuinnote/spark/bitcoin/block/SparkBitcoinBlockDSSparkMasterIntegrationSpec.scala
@@ -1,136 +1,123 @@
 /**
-* Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+  * Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 
 /**
-*
-* This test intregrates HDFS and Spark
-*
-*/
+  *
+  * This test intregrates HDFS and Spark
+  *
+  */
 
 package org.zuinnote.spark.bitcoin.block
 
-
-import org.apache.hadoop.hdfs.MiniDFSCluster
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.FSDataInputStream
-import org.apache.hadoop.fs.Path
-import java.io.BufferedReader
-import java.io.File
-import java.io.InputStream
-import java.io.InputStreamReader
-import java.io.IOException
+import java.io.{File, IOException}
 import java.nio.file.attribute.BasicFileAttributes
-import java.nio.file.Files
-import java.nio.file.FileVisitResult
-import java.nio.file.SimpleFileVisitor
-import java.util.ArrayList
-import java.util.List
+import java.nio.file.{FileVisitResult, Files, SimpleFileVisitor}
 
-import org.apache.hadoop.io.compress.CodecPool
-import org.apache.hadoop.io.compress.CompressionCodec
-import org.apache.hadoop.io.compress.CompressionCodecFactory
-import org.apache.hadoop.io.compress.Decompressor
-import org.apache.hadoop.io.compress.SplittableCompressionCodec
-import org.apache.hadoop.io.compress.SplitCompressionInputStream
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.hdfs.MiniDFSCluster
+import org.apache.hadoop.io.compress.{CodecPool, Decompressor}
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.functions._
-
-import scala.collection.mutable.ArrayBuffer
+import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, GivenWhenThen, Matchers}
-import org.zuinnote.spark.bitcoin.model.{BitcoinBlock, BitcoinBlockWithAuxPOW, EnrichedBitcoinBlock, EnrichedBitcoinBlockWithAuxPOW}
+import org.zuinnote.spark.bitcoin.model._
+
+import scala.collection.mutable
 
 class SparkBitcoinBlockDSSparkMasterIntegrationSpec extends FlatSpec with BeforeAndAfterAll with GivenWhenThen with Matchers {
 
-private var sc: SparkContext = _
-private var sqlContext: SQLContext = _
-private val master: String = "local[2]"
-private val appName: String = "spark-hadoocryptoledger-ds-integrationtest"
-private val tmpPrefix: String = "hcl-integrationtest"
-private var tmpPath: java.nio.file.Path = _
-private val CLUSTERNAME: String ="hcl-minicluster"
-private val DFS_INPUT_DIR_NAME: String = "/input"
-private val DFS_OUTPUT_DIR_NAME: String = "/output"
-private val DEFAULT_OUTPUT_FILENAME: String = "part-00000"
-private val DFS_INPUT_DIR : Path = new Path(DFS_INPUT_DIR_NAME)
-private val DFS_OUTPUT_DIR : Path = new Path(DFS_OUTPUT_DIR_NAME)
-private val NOOFDATANODES: Int =4
-private var dfsCluster: MiniDFSCluster = _
-private var conf: Configuration = _
-private var openDecompressors = ArrayBuffer[Decompressor]();
+  private var sc: SparkContext = _
+  private var sqlContext: SQLContext = _
+  private val master: String = "local[2]"
+  private val appName: String = "spark-hadoocryptoledger-ds-integrationtest"
+  private val tmpPrefix: String = "hcl-integrationtest"
+  private var tmpPath: java.nio.file.Path = _
+  private val CLUSTERNAME: String = "hcl-minicluster"
+  private val DFS_INPUT_DIR_NAME: String = "/input"
+  private val DFS_OUTPUT_DIR_NAME: String = "/output"
+  private val DEFAULT_OUTPUT_FILENAME: String = "part-00000"
+  private val DFS_INPUT_DIR: Path = new Path(DFS_INPUT_DIR_NAME)
+  private val DFS_OUTPUT_DIR: Path = new Path(DFS_OUTPUT_DIR_NAME)
+  private val NOOFDATANODES: Int = 4
+  private var dfsCluster: MiniDFSCluster = _
+  private var conf: Configuration = _
+  private val openDecompressors = mutable.ArrayBuffer[Decompressor]()
 
-override def beforeAll(): Unit = {
+  override def beforeAll(): Unit = {
     super.beforeAll()
 
-		// Create temporary directory for HDFS base and shutdownhook
-	// create temp directory
-      tmpPath = Files.createTempDirectory(tmpPrefix)
-      // create shutdown hook to remove temp files (=HDFS MiniCluster) after shutdown, may need to rethink to avoid many threads are created
-	Runtime.getRuntime.addShutdownHook(new Thread("remove temporary directory") {
-      	 override def run(): Unit =  {
-        	try {
-          		Files.walkFileTree(tmpPath, new SimpleFileVisitor[java.nio.file.Path]() {
+    // Create temporary directory for HDFS base and shutdownhook
+    // create temp directory
+    tmpPath = Files.createTempDirectory(tmpPrefix)
+    // create shutdown hook to remove temp files (=HDFS MiniCluster) after shutdown, may need to rethink to avoid many threads are created
+    Runtime.getRuntime.addShutdownHook(new Thread("remove temporary directory") {
+      override def run(): Unit = {
+        try {
+          Files.walkFileTree(tmpPath, new SimpleFileVisitor[java.nio.file.Path]() {
 
-            		override def visitFile(file: java.nio.file.Path,attrs: BasicFileAttributes): FileVisitResult = {
-                		Files.delete(file)
-             			return FileVisitResult.CONTINUE
-        			}
+            override def visitFile(file: java.nio.file.Path, attrs: BasicFileAttributes): FileVisitResult = {
+              Files.delete(file)
+              FileVisitResult.CONTINUE
+            }
 
-        		override def postVisitDirectory(dir: java.nio.file.Path, e: IOException): FileVisitResult = {
-          			if (e == null) {
-            				Files.delete(dir)
-            				return FileVisitResult.CONTINUE
-          			}
-          			throw e
-        			}
-        	})
-      	} catch {
-        case e: IOException => throw new RuntimeException("Error temporary files in following path could not be deleted "+tmpPath, e)
-    }}})
-	// create DFS mini cluster
-	 conf = new Configuration()
-	val baseDir = new File(tmpPath.toString()).getAbsoluteFile()
-	conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath())
-	val builder = new MiniDFSCluster.Builder(conf)
- 	 dfsCluster = builder.numDataNodes(NOOFDATANODES).build()
-	conf.set("fs.defaultFS", dfsCluster.getFileSystem().getUri().toString())
-	// create local Spark cluster
- 	val sparkConf = new SparkConf()
+            override def postVisitDirectory(dir: java.nio.file.Path, e: IOException): FileVisitResult = {
+              if (e != null) {
+                throw e
+              }
+
+              Files.delete(dir)
+              FileVisitResult.CONTINUE
+            }
+          })
+        } catch {
+          case e: IOException => throw new RuntimeException("Error temporary files in following path could not be deleted " + tmpPath, e)
+        }
+      }
+    })
+    // create DFS mini cluster
+    conf = new Configuration()
+    val baseDir = new File(tmpPath.toString).getAbsoluteFile
+    conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath)
+    val builder = new MiniDFSCluster.Builder(conf)
+    dfsCluster = builder.numDataNodes(NOOFDATANODES).build()
+    conf.set("fs.defaultFS", dfsCluster.getFileSystem().getUri.toString)
+    // create local Spark cluster
+    val sparkConf = new SparkConf()
       .setMaster("local[2]")
       .setAppName(this.getClass.getSimpleName)
-	sc = new SparkContext(sparkConf)
-	sqlContext = new SQLContext(sc)
- }
-
+    sc = new SparkContext(sparkConf)
+    sqlContext = new SQLContext(sc)
+  }
 
   override def afterAll(): Unit = {
-   // close Spark Context
-    if (sc!=null) {
-	sc.stop()
+    // close Spark Context
+    if (sc != null) {
+      sc.stop()
     }
     // close decompressor
-	for ( currentDecompressor <- this.openDecompressors) {
-		if (currentDecompressor!=null) {
-			 CodecPool.returnDecompressor(currentDecompressor)
-		}
- 	}
+    for (currentDecompressor <- this.openDecompressors) {
+      if (currentDecompressor != null) {
+        CodecPool.returnDecompressor(currentDecompressor)
+      }
+    }
     // close dfs cluster
     dfsCluster.shutdown()
     super.afterAll()
-}
+  }
 
 
 "The genesis block on DFS" should "be fully read in dataframe" in {
@@ -139,14 +126,14 @@ override def beforeAll(): Unit = {
    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
 	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
 	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
+	val classLoader = getClass.getClassLoader
     	// put testdata on DFS
     	val fileName: String="genesis.blk"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
+    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile
     	val inputFile=new Path(fileNameFullLocal)
     	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
 	When("reading Genesis block using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
+	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri.toString+DFS_INPUT_DIR_NAME)
 	Then("all fields should be readable trough Spark SQL")
 	// check first if structure is correct
 	assert("blockSize"==df.columns(0))
@@ -229,7 +216,6 @@ override def beforeAll(): Unit = {
 0x12.toByte,0xDE.toByte,0x5C.toByte,0x38.toByte,0x4D.toByte,0xF7.toByte,0xBA.toByte,0x0B.toByte,0x8D.toByte,0x57.toByte,0x8A.toByte,0x4C.toByte,0x70.toByte,0x2B.toByte,0x6B.toByte,0xF1.toByte,
 0x1D.toByte,0x5F.toByte,0xAC.toByte)
 	assert(txOutScriptExpected.deep==txOutScript(0).get(0).asInstanceOf[Array[Byte]].deep)
-
 }
 
 
@@ -332,68 +318,67 @@ override def beforeAll(): Unit = {
 
 	import df.sparkSession.implicits._
 
- 	df.as[BitcoinBlock].collect()
-}
+ 	df.as[BitcoinBlock].collect()}
 
-"The genesis block on DFS" should "be fully read in dataframe enriched with transactionHash" in {
-	Given("Genesis Block on DFSCluster")
-	// create input directory
-   dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
-	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
-	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
-    	// put testdata on DFS
-    	val fileName: String="genesis.blk"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
-    	val inputFile=new Path(fileNameFullLocal)
-    	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
-	When("reading Genesis block using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").option("enrich","true").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
-	Then("all fields should be readable trough Spark SQL")
-	// check first if structure is correct
-	assert("blockSize"==df.columns(0))
-	assert("magicNo"==df.columns(1))
-	assert("version"==df.columns(2))
-	assert("time"==df.columns(3))
-	assert("bits"==df.columns(4))
-	assert("nonce"==df.columns(5))
-	assert("transactionCounter"==df.columns(6))
-	assert("hashPrevBlock"==df.columns(7))
-	assert("hashMerkleRoot"==df.columns(8))
-	assert("transactions"==df.columns(9))
-	// validate block data
-	val blockSize = df.select("blockSize").collect
-	assert(285==blockSize(0).getInt(0))
-	val magicNo = df.select("magicNo").collect
-	val magicNoExpected : Array[Byte] = Array(0xF9.toByte,0xBE.toByte,0xB4.toByte,0xD9.toByte)
-	assert(magicNoExpected.deep==magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val version = df.select("version").collect
-	assert(1==version(0).getInt(0))
-	val time = df.select("time").collect
-	assert(1231006505==time(0).getInt(0))
-	val bits = df.select("bits").collect
-	val bitsExpected: Array[Byte] = Array(0xFF.toByte,0xFF.toByte,0x00.toByte,0x1D.toByte)
-	assert(bitsExpected.deep==bits(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val nonce = df.select("nonce").collect
-	assert(2083236893==nonce(0).getInt(0))
-	val transactionCounter = df.select("transactionCounter").collect
-	assert(1==transactionCounter(0).getLong(0))
-	val hashPrevBlock = df.select("hashPrevBlock").collect
-	val hashPrevBlockExpected: Array[Byte] = Array(0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte)
-	assert(hashPrevBlockExpected.deep==hashPrevBlock(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val hashMerkleRoot = df.select("hashMerkleRoot").collect
-	val hashMerkleRootExpected: Array[Byte] = Array(0x3B.toByte,0xA3.toByte,0xED.toByte,0xFD.toByte,0x7A.toByte,0x7B.toByte,0x12.toByte,0xB2.toByte,0x7A.toByte,0xC7.toByte,0x2C.toByte,0x3E.toByte,0x67.toByte,0x76.toByte,0x8F.toByte,0x61.toByte,0x7F.toByte,
-0xC8.toByte,0x1B.toByte,0xC3.toByte,0x88.toByte,0x8A.toByte,0x51.toByte,0x32.toByte,0x3A.toByte,0x9F.toByte,0xB8.toByte,0xAA.toByte,0x4B.toByte,0x1E.toByte,0x5E.toByte,0x4A.toByte)
-	assert(hashMerkleRootExpected.deep==hashMerkleRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
-	// validate transactions
-	val transactionsDF=df.select(explode(df("transactions")).alias("transactions"))
-	// one transaction
-	val transactionsDFCount = transactionsDF.count
-	assert(1==transactionsDFCount)
-  val currentTransactionHash = transactionsDF.select("transactions.currentTransactionHash").collect
-	val currentTransactionHashExpected : Array[Byte] = Array(0x3B.toByte,0xA3.toByte,0xED.toByte,0xFD.toByte,0x7A.toByte,0x7B.toByte,0x12.toByte,0xB2.toByte,0x7A.toByte,0xC7.toByte,0x2C.toByte,0x3E.toByte,0x67.toByte,0x76.toByte,0x8F.toByte,0x61.toByte,
-0x7F.toByte,0xC8.toByte,0x1B.toByte,0xC3.toByte,0x88.toByte,0x8A.toByte,0x51.toByte,0x32.toByte,0x3A.toByte,0x9F.toByte,0xB8.toByte,0xAA.toByte,0x4B.toByte,0x1E.toByte,0x5E.toByte,0x4A.toByte)
-	assert(currentTransactionHashExpected.deep==currentTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+  "The genesis block on DFS" should "be fully read in dataframe enriched with transactionHash" in {
+    Given("Genesis Block on DFSCluster")
+    // create input directory
+    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR, true)
+    dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
+    // copy bitcoin blocks
+    val classLoader = getClass.getClassLoader
+    // put testdata on DFS
+    val fileName: String = "genesis.blk"
+    val fileNameFullLocal = classLoader.getResource("testdata/" + fileName).getFile
+    val inputFile = new Path(fileNameFullLocal)
+    dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
+    When("reading Genesis block using datasource")
+    val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").option("enrich", "true").load(dfsCluster.getFileSystem().getUri.toString + DFS_INPUT_DIR_NAME)
+    Then("all fields should be readable trough Spark SQL")
+    // check first if structure is correct
+    assert("blockSize" == df.columns(0))
+    assert("magicNo" == df.columns(1))
+    assert("version" == df.columns(2))
+    assert("time" == df.columns(3))
+    assert("bits" == df.columns(4))
+    assert("nonce" == df.columns(5))
+    assert("transactionCounter" == df.columns(6))
+    assert("hashPrevBlock" == df.columns(7))
+    assert("hashMerkleRoot" == df.columns(8))
+    assert("transactions" == df.columns(9))
+    // validate block data
+    val blockSize = df.select("blockSize").collect
+    assert(285 == blockSize(0).getInt(0))
+    val magicNo = df.select("magicNo").collect
+    val magicNoExpected: Array[Byte] = Array(0xF9.toByte, 0xBE.toByte, 0xB4.toByte, 0xD9.toByte)
+    assert(magicNoExpected.deep == magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val version = df.select("version").collect
+    assert(1 == version(0).getInt(0))
+    val time = df.select("time").collect
+    assert(1231006505 == time(0).getInt(0))
+    val bits = df.select("bits").collect
+    val bitsExpected: Array[Byte] = Array(0xFF.toByte, 0xFF.toByte, 0x00.toByte, 0x1D.toByte)
+    assert(bitsExpected.deep == bits(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val nonce = df.select("nonce").collect
+    assert(2083236893 == nonce(0).getInt(0))
+    val transactionCounter = df.select("transactionCounter").collect
+    assert(1 == transactionCounter(0).getLong(0))
+    val hashPrevBlock = df.select("hashPrevBlock").collect
+    val hashPrevBlockExpected: Array[Byte] = Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)
+    assert(hashPrevBlockExpected.deep == hashPrevBlock(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val hashMerkleRoot = df.select("hashMerkleRoot").collect
+    val hashMerkleRootExpected: Array[Byte] = Array(0x3B.toByte, 0xA3.toByte, 0xED.toByte, 0xFD.toByte, 0x7A.toByte, 0x7B.toByte, 0x12.toByte, 0xB2.toByte, 0x7A.toByte, 0xC7.toByte, 0x2C.toByte, 0x3E.toByte, 0x67.toByte, 0x76.toByte, 0x8F.toByte, 0x61.toByte, 0x7F.toByte,
+      0xC8.toByte, 0x1B.toByte, 0xC3.toByte, 0x88.toByte, 0x8A.toByte, 0x51.toByte, 0x32.toByte, 0x3A.toByte, 0x9F.toByte, 0xB8.toByte, 0xAA.toByte, 0x4B.toByte, 0x1E.toByte, 0x5E.toByte, 0x4A.toByte)
+    assert(hashMerkleRootExpected.deep == hashMerkleRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
+    // validate transactions
+    val transactionsDF = df.select(explode(df("transactions")).alias("transactions"))
+    // one transaction
+    val transactionsDFCount = transactionsDF.count
+    assert(1 == transactionsDFCount)
+    val currentTransactionHash = transactionsDF.select("transactions.currentTransactionHash").collect
+    val currentTransactionHashExpected: Array[Byte] = Array(0x3B.toByte, 0xA3.toByte, 0xED.toByte, 0xFD.toByte, 0x7A.toByte, 0x7B.toByte, 0x12.toByte, 0xB2.toByte, 0x7A.toByte, 0xC7.toByte, 0x2C.toByte, 0x3E.toByte, 0x67.toByte, 0x76.toByte, 0x8F.toByte, 0x61.toByte,
+      0x7F.toByte, 0xC8.toByte, 0x1B.toByte, 0xC3.toByte, 0x88.toByte, 0x8A.toByte, 0x51.toByte, 0x32.toByte, 0x3A.toByte, 0x9F.toByte, 0xB8.toByte, 0xAA.toByte, 0x4B.toByte, 0x1E.toByte, 0x5E.toByte, 0x4A.toByte)
+    assert(currentTransactionHashExpected.deep == currentTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
 
 	val transactionsVersion=transactionsDF.select("transactions.version").collect
 	assert(1==transactionsVersion(0).getInt(0))
@@ -436,8 +421,6 @@ override def beforeAll(): Unit = {
 0x12.toByte,0xDE.toByte,0x5C.toByte,0x38.toByte,0x4D.toByte,0xF7.toByte,0xBA.toByte,0x0B.toByte,0x8D.toByte,0x57.toByte,0x8A.toByte,0x4C.toByte,0x70.toByte,0x2B.toByte,0x6B.toByte,0xF1.toByte,
 0x1D.toByte,0x5F.toByte,0xAC.toByte)
 	assert(txOutScriptExpected.deep==txOutScript(0).get(0).asInstanceOf[Array[Byte]].deep)
-
-
 }
 
 
@@ -545,174 +528,171 @@ override def beforeAll(): Unit = {
 
 	import df.sparkSession.implicits._
 
- 	df.as[EnrichedBitcoinBlock].collect()
-}
+ 	df.as[EnrichedBitcoinBlock].collect()}
 
-"The scriptwitness block on DFS" should "be read in dataframe" in {
-	Given("Scriptwitness Block on DFSCluster")
-	// create input directory
-   dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
-	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
-	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
-    	// put testdata on DFS
-    	val fileName: String="scriptwitness.blk"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
-    	val inputFile=new Path(fileNameFullLocal)
-    	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
-	When("reading scriptwitness block using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
-	Then("schema should be correct and number of transactions")
-	// check first if structure is correct
-	assert("blockSize"==df.columns(0))
-	assert("magicNo"==df.columns(1))
-	assert("version"==df.columns(2))
-	assert("time"==df.columns(3))
-	assert("bits"==df.columns(4))
-	assert("nonce"==df.columns(5))
-	assert("transactionCounter"==df.columns(6))
-	assert("hashPrevBlock"==df.columns(7))
-	assert("hashMerkleRoot"==df.columns(8))
-	assert("transactions"==df.columns(9))
-	// validate block data
-	val blockSize = df.select("blockSize").collect
-	assert(999275==blockSize(0).getInt(0))
-	val magicNo = df.select("magicNo").collect
-	val magicNoExpected : Array[Byte] = Array(0xF9.toByte,0xBE.toByte,0xB4.toByte,0xD9.toByte)
-	assert(magicNoExpected.deep==magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val version = df.select("version").collect
-	assert(536870914==version(0).getInt(0))
-	val time = df.select("time").collect
-	assert(1503889880==time(0).getInt(0))
-	val bits = df.select("bits").collect
-	val bitsExpected: Array[Byte] = Array(0xE9.toByte,0x3C.toByte,0x01.toByte,0x18.toByte)
-	assert(bitsExpected.deep==bits(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val nonce = df.select("nonce").collect
-	assert(184429655==nonce(0).getInt(0))
-	val transactionCounter = df.select("transactionCounter").collect
-	assert(470==transactionCounter(0).getLong(0))
-		// validate transactions
-	val transactionsDF=df.select(explode(df("transactions")).alias("transactions"))
+  "The scriptwitness block on DFS" should "be read in dataframe" in {
+    Given("Scriptwitness Block on DFSCluster")
+    // create input directory
+    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR, true)
+    dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
+    // copy bitcoin blocks
+    val classLoader = getClass.getClassLoader
+    // put testdata on DFS
+    val fileName: String = "scriptwitness.blk"
+    val fileNameFullLocal = classLoader.getResource("testdata/" + fileName).getFile
+    val inputFile = new Path(fileNameFullLocal)
+    dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
+    When("reading scriptwitness block using datasource")
+    val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri.toString + DFS_INPUT_DIR_NAME)
+    Then("schema should be correct and number of transactions")
+    // check first if structure is correct
+    assert("blockSize" == df.columns(0))
+    assert("magicNo" == df.columns(1))
+    assert("version" == df.columns(2))
+    assert("time" == df.columns(3))
+    assert("bits" == df.columns(4))
+    assert("nonce" == df.columns(5))
+    assert("transactionCounter" == df.columns(6))
+    assert("hashPrevBlock" == df.columns(7))
+    assert("hashMerkleRoot" == df.columns(8))
+    assert("transactions" == df.columns(9))
+    // validate block data
+    val blockSize = df.select("blockSize").collect
+    assert(999275 == blockSize(0).getInt(0))
+    val magicNo = df.select("magicNo").collect
+    val magicNoExpected: Array[Byte] = Array(0xF9.toByte, 0xBE.toByte, 0xB4.toByte, 0xD9.toByte)
+    assert(magicNoExpected.deep == magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val version = df.select("version").collect
+    assert(536870914 == version(0).getInt(0))
+    val time = df.select("time").collect
+    assert(1503889880 == time(0).getInt(0))
+    val bits = df.select("bits").collect
+    val bitsExpected: Array[Byte] = Array(0xE9.toByte, 0x3C.toByte, 0x01.toByte, 0x18.toByte)
+    assert(bitsExpected.deep == bits(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val nonce = df.select("nonce").collect
+    assert(184429655 == nonce(0).getInt(0))
+    val transactionCounter = df.select("transactionCounter").collect
+    assert(470 == transactionCounter(0).getLong(0))
+    // validate transactions
+    val transactionsDF = df.select(explode(df("transactions")).alias("transactions"))
 
-	val transactionsDFCount = transactionsDF.count
-	assert(470==transactionsDFCount)
+    val transactionsDFCount = transactionsDF.count
+    assert(470 == transactionsDFCount)
+  }
 
-}
+  "The scriptwitness2 block on DFS" should "be read in dataframe" in {
+    Given("Scriptwitness2 Block on DFSCluster")
+    // create input directory
+    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR, true)
+    dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
+    // copy bitcoin blocks
+    val classLoader = getClass.getClassLoader
+    // put testdata on DFS
+    val fileName: String = "scriptwitness2.blk"
+    val fileNameFullLocal = classLoader.getResource("testdata/" + fileName).getFile
+    val inputFile = new Path(fileNameFullLocal)
+    dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
+    When("reading scriptwitness2 block using datasource")
+    val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri.toString + DFS_INPUT_DIR_NAME)
+    Then("schema should be correct and number of transactions")
+    // check first if structure is correct
+    assert("blockSize" == df.columns(0))
+    assert("magicNo" == df.columns(1))
+    assert("version" == df.columns(2))
+    assert("time" == df.columns(3))
+    assert("bits" == df.columns(4))
+    assert("nonce" == df.columns(5))
+    assert("transactionCounter" == df.columns(6))
+    assert("hashPrevBlock" == df.columns(7))
+    assert("hashMerkleRoot" == df.columns(8))
+    assert("transactions" == df.columns(9))
+    // read data
+    val blockSize = df.select("blockSize").collect
+    val magicNo = df.select("magicNo").collect
+    val magicNoExpected: Array[Byte] = Array(0xF9.toByte, 0xBE.toByte, 0xB4.toByte, 0xD9.toByte)
+    val time = df.select("time").collect
+    val version = df.select("version").collect
+    val bits = df.select("bits").collect
+    val bitsExpected: Array[Byte] = Array(0xE9.toByte, 0x3C.toByte, 0x01.toByte, 0x18.toByte)
+    val transactionCounter = df.select("transactionCounter").collect
+    val nonce = df.select("nonce").collect
+    // first block
+    // validate block data
+    assert(1000031 == blockSize(0).getInt(0))
+    assert(magicNoExpected.deep == magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
+    assert(536870912 == version(0).getInt(0))
+    assert(1503863706 == time(0).getInt(0))
+    assert(bitsExpected.deep == bits(0).get(0).asInstanceOf[Array[Byte]].deep)
+    assert(-706531299 == nonce(0).getInt(0))
+    assert(2191 == transactionCounter(0).getLong(0))
 
+    // second block
+    // validate block data
+    assert(999304 == blockSize(1).getInt(0))
+    assert(magicNoExpected.deep == magicNo(1).get(0).asInstanceOf[Array[Byte]].deep)
+    assert(536870912 == version(1).getInt(0))
+    assert(1503836377 == time(1).getInt(0))
+    assert(bitsExpected.deep == bits(1).get(0).asInstanceOf[Array[Byte]].deep)
+    assert(-566627396 == nonce(1).getInt(0))
+    assert(2508 == transactionCounter(1).getLong(0))
+    // check transactions
+    val transactionsDF = df.select(explode(df("transactions")).alias("transactions"))
+    val transactionsDFCount = transactionsDF.count
+    val transActBothBlocks = 2191 + 2508
+    assert(transActBothBlocks == transactionsDFCount)
+  }
 
-"The scriptwitness2 block on DFS" should "be read in dataframe" in {
-	Given("Scriptwitness2 Block on DFSCluster")
-	// create input directory
-   dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
-	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
-	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
-    	// put testdata on DFS
-    	val fileName: String="scriptwitness2.blk"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
-    	val inputFile=new Path(fileNameFullLocal)
-    	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
-	When("reading scriptwitness2 block using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
-	Then("schema should be correct and number of transactions")
-	// check first if structure is correct
-	assert("blockSize"==df.columns(0))
-	assert("magicNo"==df.columns(1))
-	assert("version"==df.columns(2))
-	assert("time"==df.columns(3))
-	assert("bits"==df.columns(4))
-	assert("nonce"==df.columns(5))
-	assert("transactionCounter"==df.columns(6))
-	assert("hashPrevBlock"==df.columns(7))
-	assert("hashMerkleRoot"==df.columns(8))
-	assert("transactions"==df.columns(9))
-  // read data
-  val blockSize = df.select("blockSize").collect
-  val magicNo = df.select("magicNo").collect
-  val magicNoExpected : Array[Byte] = Array(0xF9.toByte,0xBE.toByte,0xB4.toByte,0xD9.toByte)
-  	val time = df.select("time").collect
-  val version = df.select("version").collect
-  val bits = df.select("bits").collect
-  val bitsExpected: Array[Byte] = Array(0xE9.toByte,0x3C.toByte,0x01.toByte,0x18.toByte)
-  	val transactionCounter = df.select("transactionCounter").collect
-  val nonce = df.select("nonce").collect
-  // first block
-	// validate block data
-	assert(1000031==blockSize(0).getInt(0))
-	assert(magicNoExpected.deep==magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
-	assert(536870912==version(0).getInt(0))
-	assert(1503863706==time(0).getInt(0))
-	assert(bitsExpected.deep==bits(0).get(0).asInstanceOf[Array[Byte]].deep)
-	assert(-706531299==nonce(0).getInt(0))
-	assert(2191 ==transactionCounter(0).getLong(0))
+  "The Namecoin block on DFS with AuxPOW information" should "be read in dataframe" in {
+    Given("Namecoin Block on DFSCluster")
+    // create input directory
+    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR, true)
+    dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
+    // copy bitcoin blocks
+    val classLoader = getClass.getClassLoader
+    // put testdata on DFS
+    val fileName: String = "namecointhreedifferentopinoneblock.blk"
+    val fileNameFullLocal = classLoader.getResource("testdata/" + fileName).getFile
+    val inputFile = new Path(fileNameFullLocal)
+    dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
+    When("reading scriptwitness block using datasource")
+    val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4FE").option("readAuxPOW", "true").load(dfsCluster.getFileSystem().getUri.toString + DFS_INPUT_DIR_NAME)
+    Then("schema should be correct and number of transactions")
 
-  // second block
-  // validate block data
-  assert(999304==blockSize(1).getInt(0))
-  assert(magicNoExpected.deep==magicNo(1).get(0).asInstanceOf[Array[Byte]].deep)
-  assert(536870912==version(1).getInt(0))
-  assert(1503836377==time(1).getInt(0))
-  assert(bitsExpected.deep==bits(1).get(0).asInstanceOf[Array[Byte]].deep)
-  assert(-566627396==nonce(1).getInt(0))
-  assert(2508 ==transactionCounter(1).getLong(0))
- // check transactions
-  val transactionsDF=df.select(explode(df("transactions")).alias("transactions"))
- val transactionsDFCount = transactionsDF.count
- val transActBothBlocks= 2191+2508
-  assert(transActBothBlocks==transactionsDFCount)
-
-}
-
-"The Namecoin block on DFS with AuxPOW information" should "be read in dataframe" in {
-	Given("Namecoin Block on DFSCluster")
-	// create input directory
-   dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
-	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
-	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
-    	// put testdata on DFS
-    	val fileName: String="namecointhreedifferentopinoneblock.blk"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
-    	val inputFile=new Path(fileNameFullLocal)
-    	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
-	When("reading scriptwitness block using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.block").option("magic", "F9BEB4FE").option("readAuxPOW","true").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
-	Then("schema should be correct and number of transactions")
-
-	// check first if structure is correct
-	assert("blockSize"==df.columns(0))
-	assert("magicNo"==df.columns(1))
-	assert("version"==df.columns(2))
-	assert("time"==df.columns(3))
-	assert("bits"==df.columns(4))
-	assert("nonce"==df.columns(5))
-	assert("transactionCounter"==df.columns(6))
-	assert("hashPrevBlock"==df.columns(7))
-	assert("hashMerkleRoot"==df.columns(8))
-	assert("transactions"==df.columns(9))
-  	assert("auxPOW"==df.columns(10))
-	// validate block data
-	val blockSize = df.select("blockSize").collect
-	assert(3125==blockSize(0).getInt(0))
-	val magicNo = df.select("magicNo").collect
-	val magicNoExpected : Array[Byte] = Array(0xF9.toByte,0xBE.toByte,0xB4.toByte,0xFE.toByte)
-	assert(magicNoExpected.deep==magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val version = df.select("version").collect
-	assert(65796==version(0).getInt(0))
-	val time = df.select("time").collect
-	assert(1506767051==time(0).getInt(0))
-	val bits = df.select("bits").collect
-	val bitsExpected: Array[Byte] = Array(0x71.toByte,0x63.toByte,0x01.toByte,0x18.toByte)
-	assert(bitsExpected.deep==bits(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val nonce = df.select("nonce").collect
-	assert(0==nonce(0).getInt(0))
-	val transactionCounter = df.select("transactionCounter").collect
-	assert(7==transactionCounter(0).getLong(0))
-		// validate transactions
-	val transactionsDF=df.select(explode(df("transactions")).alias("transactions"))
+    // check first if structure is correct
+    assert("blockSize" == df.columns(0))
+    assert("magicNo" == df.columns(1))
+    assert("version" == df.columns(2))
+    assert("time" == df.columns(3))
+    assert("bits" == df.columns(4))
+    assert("nonce" == df.columns(5))
+    assert("transactionCounter" == df.columns(6))
+    assert("hashPrevBlock" == df.columns(7))
+    assert("hashMerkleRoot" == df.columns(8))
+    assert("transactions" == df.columns(9))
+    assert("auxPOW" == df.columns(10))
+    // validate block data
+    val blockSize = df.select("blockSize").collect
+    assert(3125 == blockSize(0).getInt(0))
+    val magicNo = df.select("magicNo").collect
+    val magicNoExpected: Array[Byte] = Array(0xF9.toByte, 0xBE.toByte, 0xB4.toByte, 0xFE.toByte)
+    assert(magicNoExpected.deep == magicNo(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val version = df.select("version").collect
+    assert(65796 == version(0).getInt(0))
+    val time = df.select("time").collect
+    assert(1506767051 == time(0).getInt(0))
+    val bits = df.select("bits").collect
+    val bitsExpected: Array[Byte] = Array(0x71.toByte, 0x63.toByte, 0x01.toByte, 0x18.toByte)
+    assert(bitsExpected.deep == bits(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val nonce = df.select("nonce").collect
+    assert(0 == nonce(0).getInt(0))
+    val transactionCounter = df.select("transactionCounter").collect
+    assert(7 == transactionCounter(0).getLong(0))
+    // validate transactions
+    val transactionsDF = df.select(explode(df("transactions")).alias("transactions"))
 
 	val transactionsDFCount = transactionsDF.count
 	assert(7==transactionsDFCount)
+
 }
 
 
@@ -793,5 +773,4 @@ override def beforeAll(): Unit = {
 
  	df.as[EnrichedBitcoinBlockWithAuxPOW].collect()
 }
-
 }

--- a/src/it/scala/org/zuinnote/spark/bitcoin/transaction/SparkBitcoinTransactionDSSparkMasterIntegrationSpec.scala
+++ b/src/it/scala/org/zuinnote/spark/bitcoin/transaction/SparkBitcoinTransactionDSSparkMasterIntegrationSpec.scala
@@ -1,211 +1,202 @@
 /**
-* Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+  * Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 
 /**
-*
-* This test intregrates HDFS and Spark
-*
-*/
+  *
+  * This test intregrates HDFS and Spark
+  *
+  */
 
 package org.zuinnote.spark.bitcoin.transaction
 
+import java.io.{File, IOException}
+import java.nio.file.{FileVisitResult, Files, SimpleFileVisitor}
+import java.nio.file.attribute.BasicFileAttributes
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+
+
 
 import org.apache.hadoop.hdfs.MiniDFSCluster
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.FSDataInputStream
-import org.apache.hadoop.fs.Path
-import java.io.BufferedReader
-import java.io.File
-import java.io.InputStream
-import java.io.InputStreamReader
-import java.io.IOException
-import java.nio.file.attribute.BasicFileAttributes
-import java.nio.file.Files
-import java.nio.file.FileVisitResult
-import java.nio.file.SimpleFileVisitor
-import java.util.ArrayList
-import java.util.List
-
-import org.apache.hadoop.io.compress.CodecPool
-import org.apache.hadoop.io.compress.CompressionCodec
-import org.apache.hadoop.io.compress.CompressionCodecFactory
-import org.apache.hadoop.io.compress.Decompressor
-import org.apache.hadoop.io.compress.SplittableCompressionCodec
-import org.apache.hadoop.io.compress.SplitCompressionInputStream
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.hadoop.io.compress.{CodecPool,Decompressor
+}
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.functions._
 
+import org.apache.spark.{SparkConf, SparkContext}
 import scala.collection.mutable.ArrayBuffer
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, GivenWhenThen, Matchers}
 import org.zuinnote.spark.bitcoin.model.{EnrichedTransaction, Transaction}
 
 class SparkBitcoinTransactionDSSparkMasterIntegrationSpec extends FlatSpec with BeforeAndAfterAll with GivenWhenThen with Matchers {
 
-private var sc: SparkContext = _
-private var sqlContext: SQLContext = _
-private val master: String = "local[2]"
-private val appName: String = "spark-hadoocryptoledger-ds-integrationtest"
-private val tmpPrefix: String = "hcl-integrationtest"
-private var tmpPath: java.nio.file.Path = _
-private val CLUSTERNAME: String ="hcl-minicluster"
-private val DFS_INPUT_DIR_NAME: String = "/input"
-private val DFS_OUTPUT_DIR_NAME: String = "/output"
-private val DEFAULT_OUTPUT_FILENAME: String = "part-00000"
-private val DFS_INPUT_DIR : Path = new Path(DFS_INPUT_DIR_NAME)
-private val DFS_OUTPUT_DIR : Path = new Path(DFS_OUTPUT_DIR_NAME)
-private val NOOFDATANODES: Int =4
-private var dfsCluster: MiniDFSCluster = _
-private var conf: Configuration = _
-private var openDecompressors = ArrayBuffer[Decompressor]();
+  private var sc: SparkContext = _
+  private var sqlContext: SQLContext = _
+  private val master: String = "local[2]"
+  private val appName: String = "spark-hadoocryptoledger-ds-integrationtest"
+  private val tmpPrefix: String = "hcl-integrationtest"
+  private var tmpPath: java.nio.file.Path = _
+  private val CLUSTERNAME: String = "hcl-minicluster"
+  private val DFS_INPUT_DIR_NAME: String = "/input"
+  private val DFS_OUTPUT_DIR_NAME: String = "/output"
+  private val DEFAULT_OUTPUT_FILENAME: String = "part-00000"
+  private val DFS_INPUT_DIR: Path = new Path(DFS_INPUT_DIR_NAME)
+  private val DFS_OUTPUT_DIR: Path = new Path(DFS_OUTPUT_DIR_NAME)
+  private val NOOFDATANODES: Int = 4
+  private var dfsCluster: MiniDFSCluster = _
+  private var conf: Configuration = _
+  private var openDecompressors = ArrayBuffer[Decompressor]()
 
-override def beforeAll(): Unit = {
+  override def beforeAll(): Unit = {
     super.beforeAll()
 
-		// Create temporary directory for HDFS base and shutdownhook
-	// create temp directory
-      tmpPath = Files.createTempDirectory(tmpPrefix)
-      // create shutdown hook to remove temp files (=HDFS MiniCluster) after shutdown, may need to rethink to avoid many threads are created
-	Runtime.getRuntime.addShutdownHook(new Thread("remove temporary directory") {
-      	 override def run(): Unit =  {
-        	try {
-          		Files.walkFileTree(tmpPath, new SimpleFileVisitor[java.nio.file.Path]() {
+    // Create temporary directory for HDFS base and shutdownhook
+    // create temp directory
+    tmpPath = Files.createTempDirectory(tmpPrefix)
+    // create shutdown hook to remove temp files (=HDFS MiniCluster) after shutdown, may need to rethink to avoid many threads are created
+    Runtime.getRuntime.addShutdownHook(new Thread("remove temporary directory") {
+      override def run(): Unit = {
+        try {
+          Files.walkFileTree(tmpPath, new SimpleFileVisitor[java.nio.file.Path]() {
 
-            		override def visitFile(file: java.nio.file.Path,attrs: BasicFileAttributes): FileVisitResult = {
-                		Files.delete(file)
-             			return FileVisitResult.CONTINUE
-        			}
+            override def visitFile(file: java.nio.file.Path, attrs: BasicFileAttributes): FileVisitResult = {
+              Files.delete(file)
+              FileVisitResult.CONTINUE
+            }
 
-        		override def postVisitDirectory(dir: java.nio.file.Path, e: IOException): FileVisitResult = {
-          			if (e == null) {
-            				Files.delete(dir)
-            				return FileVisitResult.CONTINUE
-          			}
-          			throw e
-        			}
-        	})
-      	} catch {
-        case e: IOException => throw new RuntimeException("Error temporary files in following path could not be deleted "+tmpPath, e)
-    }}})
-	// create DFS mini cluster
-	 conf = new Configuration()
-	val baseDir = new File(tmpPath.toString()).getAbsoluteFile()
-	conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath())
-	val builder = new MiniDFSCluster.Builder(conf)
- 	 dfsCluster = builder.numDataNodes(NOOFDATANODES).build()
-	conf.set("fs.defaultFS", dfsCluster.getFileSystem().getUri().toString())
-	// create local Spark cluster
- 	val sparkConf = new SparkConf()
+            override def postVisitDirectory(dir: java.nio.file.Path, e: IOException): FileVisitResult = {
+              if (e != null) {
+                throw e
+              }
+
+              Files.delete(dir)
+              FileVisitResult.CONTINUE
+            }
+          })
+        } catch {
+          case e: IOException => throw new RuntimeException("Error temporary files in following path could not be deleted " + tmpPath, e)
+        }
+      }
+    })
+    // create DFS mini cluster
+    conf = new Configuration()
+    val baseDir = new File(tmpPath.toString).getAbsoluteFile
+    conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath)
+    val builder = new MiniDFSCluster.Builder(conf)
+    dfsCluster = builder.numDataNodes(NOOFDATANODES).build()
+    conf.set("fs.defaultFS", dfsCluster.getFileSystem().getUri.toString)
+    // create local Spark cluster
+    val sparkConf = new SparkConf()
       .setMaster("local[2]")
       .setAppName(this.getClass.getSimpleName)
-	sc = new SparkContext(sparkConf)
-	sqlContext = new SQLContext(sc)
- }
-
+    sc = new SparkContext(sparkConf)
+    sqlContext = new SQLContext(sc)
+  }
 
   override def afterAll(): Unit = {
-   // close Spark Context
-    if (sc!=null) {
-	sc.stop()
+    // close Spark Context
+    if (sc != null) {
+      sc.stop()
     }
     // close decompressor
-	for ( currentDecompressor <- this.openDecompressors) {
-		if (currentDecompressor!=null) {
-			 CodecPool.returnDecompressor(currentDecompressor)
-		}
- 	}
+    for (currentDecompressor <- this.openDecompressors) {
+      if (currentDecompressor != null) {
+        CodecPool.returnDecompressor(currentDecompressor)
+      }
+    }
     // close dfs cluster
     dfsCluster.shutdown()
     super.afterAll()
-}
+  }
 
-
-"The genesis block on DFS" should "be fully read in dataframe" in {
-	Given("Genesis Block on DFSCluster")
-	// create input directory
-     dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
-	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
-	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
-    	// put testdata on DFS
-    	val fileName: String="genesis.blk"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
-    	val inputFile=new Path(fileNameFullLocal)
-    	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
-	When("reading Genesis block using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.transaction").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
-	Then("all fields should be readable trough Spark SQL")
-	// check first if structure is correct
-	assert("currentTransactionHash"==df.columns(0))
-	assert("version"==df.columns(1))
-  	assert("marker"==df.columns(2))
-    	assert("flag"==df.columns(3))
-	assert("inCounter"==df.columns(4))
-	assert("outCounter"==df.columns(5))
-	assert("listOfInputs"==df.columns(6))
-	assert("listOfOutputs"==df.columns(7))
-  assert("listOfScriptWitnessItem"==df.columns(8))
-	assert("lockTime"==df.columns(9))
-	// validate transaction data
-	val currentTransactionHash = df.select("currentTransactionHash").collect
-	val currentTransactionHashExpected : Array[Byte] = Array(0x3B.toByte,0xA3.toByte,0xED.toByte,0xFD.toByte,0x7A.toByte,0x7B.toByte,0x12.toByte,0xB2.toByte,0x7A.toByte,0xC7.toByte,0x2C.toByte,0x3E.toByte,0x67.toByte,0x76.toByte,0x8F.toByte,0x61.toByte,
-0x7F.toByte,0xC8.toByte,0x1B.toByte,0xC3.toByte,0x88.toByte,0x8A.toByte,0x51.toByte,0x32.toByte,0x3A.toByte,0x9F.toByte,0xB8.toByte,0xAA.toByte,0x4B.toByte,0x1E.toByte,0x5E.toByte,0x4A.toByte)
-	assert(currentTransactionHashExpected.deep==currentTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val version = df.select("version").collect
-	assert(1==version(0).getInt(0))
-	val inCounter = df.select("inCounter").collect
-	val inCounterExpected: Array[Byte] = Array(0x01.toByte)
-	assert(inCounterExpected.deep==inCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val outCounter = df.select("outCounter").collect
-	val outCounterExpected: Array[Byte] = Array(0x01.toByte)
-	assert(outCounterExpected.deep==outCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val transactionsLockTime=df.select("lockTime").collect
-	assert(0==transactionsLockTime(0).getInt(0))
-	val transactionsLOIDF = df.select(explode(df("listOfInputs")).alias("listOfInputs"))
-	val prevTransactionHash = transactionsLOIDF.select("listOfInputs.prevTransactionHash").collect
-	val prevTransactionHashExpected: Array[Byte] = Array(0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte)
-	assert(prevTransactionHashExpected.deep==prevTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val previousTxOutIndex = transactionsLOIDF.select("listOfInputs.previousTxOutIndex").collect
-	assert(4294967295L==previousTxOutIndex(0).getLong(0))
-	val txInScriptLength = transactionsLOIDF.select("listOfInputs.txInScriptLength").collect
-	val txInScriptLengthExpected: Array[Byte] = Array(0x4D.toByte)
-	assert(txInScriptLengthExpected.deep==txInScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val txInScript = transactionsLOIDF.select("listOfInputs.txInScript").collect
-	val txInScriptExpected: Array[Byte] =Array(0x04.toByte,0xFF.toByte,0xFF.toByte,0x00.toByte,0x1D.toByte,0x01.toByte,0x04.toByte,0x45.toByte,0x54.toByte,0x68.toByte,0x65.toByte,0x20.toByte,0x54.toByte,0x69.toByte,0x6D.toByte,0x65.toByte,
-0x73.toByte,0x20.toByte,0x30.toByte,0x33.toByte,0x2F.toByte,0x4A.toByte,0x61.toByte,0x6E.toByte,0x2F.toByte,0x32.toByte,0x30.toByte,0x30.toByte,0x39.toByte,0x20.toByte,0x43.toByte,0x68.toByte,
-0x61.toByte,0x6E.toByte,0x63.toByte,0x65.toByte,0x6C.toByte,0x6C.toByte,0x6F.toByte,0x72.toByte,0x20.toByte,0x6F.toByte,0x6E.toByte,0x20.toByte,0x62.toByte,0x72.toByte,0x69.toByte,0x6E.toByte,0x6B.toByte,
-0x20.toByte,0x6F.toByte,0x66.toByte,0x20.toByte,0x73.toByte,0x65.toByte,0x63.toByte,0x6F.toByte,0x6E.toByte,0x64.toByte,0x20.toByte,0x62.toByte,0x61.toByte,0x69.toByte,0x6C.toByte,0x6F.toByte,
-0x75.toByte,0x74.toByte,0x20.toByte,0x66.toByte,0x6F.toByte,0x72.toByte,0x20.toByte,0x62.toByte,0x61.toByte,0x6E.toByte,0x6B.toByte,0x73.toByte)
-	assert(txInScriptExpected.deep==txInScript(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val seqNo = transactionsLOIDF.select("listOfInputs.seqNo").collect
-	assert(4294967295L==seqNo(0).getLong(0))
-	val transactionsLOODF = df.select(explode(df("listOfOutputs")).alias("listOfOutputs"))
-	val value = transactionsLOODF.select("listOfOutputs.value").collect
-	assert(5000000000L==value(0).getLong(0))
-	val txOutScriptLength = transactionsLOODF.select("listOfOutputs.txOutScriptLength").collect
-	val txOutScriptLengthExpected: Array[Byte] = Array(0x43.toByte)
-	assert(txOutScriptLengthExpected.deep==txOutScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
-	val txOutScript = transactionsLOODF.select("listOfOutputs.txOutScript").collect
-	val txOutScriptExpected: Array[Byte] = Array(0x41.toByte,0x04.toByte,0x67.toByte,0x8A.toByte,0xFD.toByte,0xB0.toByte,0xFE.toByte,0x55.toByte,0x48.toByte,0x27.toByte,0x19.toByte,0x67.toByte,0xF1.toByte,0xA6.toByte,0x71.toByte,0x30.toByte,
-0xB7.toByte,0x10.toByte,0x5C.toByte,0xD6.toByte,0xA8.toByte,0x28.toByte,0xE0.toByte,0x39.toByte,0x09.toByte,0xA6.toByte,0x79.toByte,0x62.toByte,0xE0.toByte,0xEA.toByte,0x1F.toByte,0x61.toByte,
-0xDE.toByte,0xB6.toByte,0x49.toByte,0xF6.toByte,0xBC.toByte,0x3F.toByte,0x4C.toByte,0xEF.toByte,0x38.toByte,0xC4.toByte,0xF3.toByte,0x55.toByte,0x04.toByte,0xE5.toByte,0x1E.toByte,0xC1.toByte,
-0x12.toByte,0xDE.toByte,0x5C.toByte,0x38.toByte,0x4D.toByte,0xF7.toByte,0xBA.toByte,0x0B.toByte,0x8D.toByte,0x57.toByte,0x8A.toByte,0x4C.toByte,0x70.toByte,0x2B.toByte,0x6B.toByte,0xF1.toByte,
-0x1D.toByte,0x5F.toByte,0xAC.toByte)
-	assert(txOutScriptExpected.deep==txOutScript(0).get(0).asInstanceOf[Array[Byte]].deep)
-}
+  "The genesis block on DFS" should "be fully read in dataframe" in {
+    Given("Genesis Block on DFSCluster")
+    // create input directory
+    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR, true)
+    dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
+    // copy bitcoin blocks
+    val classLoader = getClass.getClassLoader
+    // put testdata on DFS
+    val fileName: String = "genesis.blk"
+    val fileNameFullLocal = classLoader.getResource("testdata/" + fileName).getFile
+    val inputFile = new Path(fileNameFullLocal)
+    dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
+    When("reading Genesis block using datasource")
+    val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.transaction").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri.toString + DFS_INPUT_DIR_NAME)
+    Then("all fields should be readable trough Spark SQL")
+    // check first if structure is correct
+    assert("currentTransactionHash" == df.columns(0))
+    assert("version" == df.columns(1))
+    assert("marker" == df.columns(2))
+    assert("flag" == df.columns(3))
+    assert("inCounter" == df.columns(4))
+    assert("outCounter" == df.columns(5))
+    assert("listOfInputs" == df.columns(6))
+    assert("listOfOutputs" == df.columns(7))
+    assert("listOfScriptWitnessItem" == df.columns(8))
+    assert("lockTime" == df.columns(9))
+    // validate transaction data
+    val currentTransactionHash = df.select("currentTransactionHash").collect
+    val currentTransactionHashExpected: Array[Byte] = Array(0x3B.toByte, 0xA3.toByte, 0xED.toByte, 0xFD.toByte, 0x7A.toByte, 0x7B.toByte, 0x12.toByte, 0xB2.toByte, 0x7A.toByte, 0xC7.toByte, 0x2C.toByte, 0x3E.toByte, 0x67.toByte, 0x76.toByte, 0x8F.toByte, 0x61.toByte,
+      0x7F.toByte, 0xC8.toByte, 0x1B.toByte, 0xC3.toByte, 0x88.toByte, 0x8A.toByte, 0x51.toByte, 0x32.toByte, 0x3A.toByte, 0x9F.toByte, 0xB8.toByte, 0xAA.toByte, 0x4B.toByte, 0x1E.toByte, 0x5E.toByte, 0x4A.toByte)
+    assert(currentTransactionHashExpected.deep == currentTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val version = df.select("version").collect
+    assert(1 == version(0).getInt(0))
+    val inCounter = df.select("inCounter").collect
+    val inCounterExpected: Array[Byte] = Array(0x01.toByte)
+    assert(inCounterExpected.deep == inCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val outCounter = df.select("outCounter").collect
+    val outCounterExpected: Array[Byte] = Array(0x01.toByte)
+    assert(outCounterExpected.deep == outCounter(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val transactionsLockTime = df.select("lockTime").collect
+    assert(0 == transactionsLockTime(0).getInt(0))
+    val transactionsLOIDF = df.select(explode(df("listOfInputs")).alias("listOfInputs"))
+    val prevTransactionHash = transactionsLOIDF.select("listOfInputs.prevTransactionHash").collect
+    val prevTransactionHashExpected: Array[Byte] = Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)
+    assert(prevTransactionHashExpected.deep == prevTransactionHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val previousTxOutIndex = transactionsLOIDF.select("listOfInputs.previousTxOutIndex").collect
+    assert(4294967295L == previousTxOutIndex(0).getLong(0))
+    val txInScriptLength = transactionsLOIDF.select("listOfInputs.txInScriptLength").collect
+    val txInScriptLengthExpected: Array[Byte] = Array(0x4D.toByte)
+    assert(txInScriptLengthExpected.deep == txInScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val txInScript = transactionsLOIDF.select("listOfInputs.txInScript").collect
+    val txInScriptExpected: Array[Byte] = Array(0x04.toByte, 0xFF.toByte, 0xFF.toByte, 0x00.toByte, 0x1D.toByte, 0x01.toByte, 0x04.toByte, 0x45.toByte, 0x54.toByte, 0x68.toByte, 0x65.toByte, 0x20.toByte, 0x54.toByte, 0x69.toByte, 0x6D.toByte, 0x65.toByte,
+      0x73.toByte, 0x20.toByte, 0x30.toByte, 0x33.toByte, 0x2F.toByte, 0x4A.toByte, 0x61.toByte, 0x6E.toByte, 0x2F.toByte, 0x32.toByte, 0x30.toByte, 0x30.toByte, 0x39.toByte, 0x20.toByte, 0x43.toByte, 0x68.toByte,
+      0x61.toByte, 0x6E.toByte, 0x63.toByte, 0x65.toByte, 0x6C.toByte, 0x6C.toByte, 0x6F.toByte, 0x72.toByte, 0x20.toByte, 0x6F.toByte, 0x6E.toByte, 0x20.toByte, 0x62.toByte, 0x72.toByte, 0x69.toByte, 0x6E.toByte, 0x6B.toByte,
+      0x20.toByte, 0x6F.toByte, 0x66.toByte, 0x20.toByte, 0x73.toByte, 0x65.toByte, 0x63.toByte, 0x6F.toByte, 0x6E.toByte, 0x64.toByte, 0x20.toByte, 0x62.toByte, 0x61.toByte, 0x69.toByte, 0x6C.toByte, 0x6F.toByte,
+      0x75.toByte, 0x74.toByte, 0x20.toByte, 0x66.toByte, 0x6F.toByte, 0x72.toByte, 0x20.toByte, 0x62.toByte, 0x61.toByte, 0x6E.toByte, 0x6B.toByte, 0x73.toByte)
+    assert(txInScriptExpected.deep == txInScript(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val seqNo = transactionsLOIDF.select("listOfInputs.seqNo").collect
+    assert(4294967295L == seqNo(0).getLong(0))
+    val transactionsLOODF = df.select(explode(df("listOfOutputs")).alias("listOfOutputs"))
+    val value = transactionsLOODF.select("listOfOutputs.value").collect
+    assert(5000000000L == value(0).getLong(0))
+    val txOutScriptLength = transactionsLOODF.select("listOfOutputs.txOutScriptLength").collect
+    val txOutScriptLengthExpected: Array[Byte] = Array(0x43.toByte)
+    assert(txOutScriptLengthExpected.deep == txOutScriptLength(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val txOutScript = transactionsLOODF.select("listOfOutputs.txOutScript").collect
+    val txOutScriptExpected: Array[Byte] = Array(0x41.toByte, 0x04.toByte, 0x67.toByte, 0x8A.toByte, 0xFD.toByte, 0xB0.toByte, 0xFE.toByte, 0x55.toByte, 0x48.toByte, 0x27.toByte, 0x19.toByte, 0x67.toByte, 0xF1.toByte, 0xA6.toByte, 0x71.toByte, 0x30.toByte,
+      0xB7.toByte, 0x10.toByte, 0x5C.toByte, 0xD6.toByte, 0xA8.toByte, 0x28.toByte, 0xE0.toByte, 0x39.toByte, 0x09.toByte, 0xA6.toByte, 0x79.toByte, 0x62.toByte, 0xE0.toByte, 0xEA.toByte, 0x1F.toByte, 0x61.toByte,
+      0xDE.toByte, 0xB6.toByte, 0x49.toByte, 0xF6.toByte, 0xBC.toByte, 0x3F.toByte, 0x4C.toByte, 0xEF.toByte, 0x38.toByte, 0xC4.toByte, 0xF3.toByte, 0x55.toByte, 0x04.toByte, 0xE5.toByte, 0x1E.toByte, 0xC1.toByte,
+      0x12.toByte, 0xDE.toByte, 0x5C.toByte, 0x38.toByte, 0x4D.toByte, 0xF7.toByte, 0xBA.toByte, 0x0B.toByte, 0x8D.toByte, 0x57.toByte, 0x8A.toByte, 0x4C.toByte, 0x70.toByte, 0x2B.toByte, 0x6B.toByte, 0xF1.toByte,
+      0x1D.toByte, 0x5F.toByte, 0xAC.toByte)
+    assert(txOutScriptExpected.deep == txOutScript(0).get(0).asInstanceOf[Array[Byte]].deep)
+  }
 
 
 "The random scriptwitness block on DFS" should "be read in dataframe" in {
@@ -214,14 +205,14 @@ override def beforeAll(): Unit = {
      dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
 	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
 	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
+	val classLoader = getClass.getClassLoader
     	// put testdata on DFS
     	val fileName: String="scriptwitness.blk"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
+    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile
     	val inputFile=new Path(fileNameFullLocal)
     	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
 	When("reading Genesis block using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.transaction").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
+	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.transaction").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri.toString+DFS_INPUT_DIR_NAME)
 	Then("all fields should be readable trough Spark SQL")
 	// check first if structure is correct
 	assert("currentTransactionHash"==df.columns(0))
@@ -238,10 +229,9 @@ override def beforeAll(): Unit = {
 	val noOfTransactions = df.count
 	assert(470==noOfTransactions)
 
-	import df.sparkSession.implicits._
+import df.sparkSession.implicits._
 
-	df.as[Transaction].collect()
-}
+	df.as[Transaction].collect()}
 
 "The random scriptwitness2 block on DFS" should "be read in dataframe" in {
 	Given("Genesis Block on DFSCluster")
@@ -249,14 +239,14 @@ override def beforeAll(): Unit = {
      dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
 	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
 	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
+	val classLoader = getClass.getClassLoader
     	// put testdata on DFS
     	val fileName: String="scriptwitness2.blk"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
+    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile
     	val inputFile=new Path(fileNameFullLocal)
     	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
 	When("reading Genesis block using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.transaction").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
+	val df = sqlContext.read.format("org.zuinnote.spark.bitcoin.transaction").option("magic", "F9BEB4D9").load(dfsCluster.getFileSystem().getUri.toString+DFS_INPUT_DIR_NAME)
   Then("all fields should be readable trough Spark SQL")
 	// check first if structure is correct
 	assert("currentTransactionHash"==df.columns(0))
@@ -295,5 +285,7 @@ override def beforeAll(): Unit = {
 
 	df.as[EnrichedTransaction].collect()
 }
+
+
 
 }

--- a/src/it/scala/org/zuinnote/spark/ethereum/block/SparkEthereumBlockDSSparkMasterIntegrationSpec.scala
+++ b/src/it/scala/org/zuinnote/spark/ethereum/block/SparkEthereumBlockDSSparkMasterIntegrationSpec.scala
@@ -22,27 +22,22 @@
 
 package org.zuinnote.spark.ethereum.block
 
-
-
 import java.io.{File, IOException}
-import java.nio.file.{FileVisitResult, Files, SimpleFileVisitor}
 import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileVisitResult, Files, SimpleFileVisitor}
 import java.text.SimpleDateFormat
-
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hdfs.MiniDFSCluster
-import org.apache.hadoop.io.compress.{CodecPool,Decompressor
-}
+import org.apache.hadoop.io.compress.{CodecPool, Decompressor}
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.functions._
-
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, GivenWhenThen, Matchers}
-import scala.collection.mutable.ArrayBuffer
-import scala.collection.JavaConversions._
 import org.zuinnote.spark.ethereum.model.{EnrichedEthereumBlock, EthereumBlock}
+
+import scala.collection.mutable
 
 class SparkEthereumBlockDSSparkMasterIntegrationSpec extends FlatSpec with BeforeAndAfterAll with GivenWhenThen with Matchers {
 
@@ -61,7 +56,7 @@ class SparkEthereumBlockDSSparkMasterIntegrationSpec extends FlatSpec with Befor
   private val NOOFDATANODES: Int = 4
   private var dfsCluster: MiniDFSCluster = _
   private var conf: Configuration = _
-  private var openDecompressors = ArrayBuffer[Decompressor]()
+  private var openDecompressors = mutable.ArrayBuffer[Decompressor]()
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -124,26 +119,25 @@ class SparkEthereumBlockDSSparkMasterIntegrationSpec extends FlatSpec with Befor
     super.afterAll()
   }
 
-
-"The block 1346406 on DFS" should "be fully read in dataframe" in {
-	Given("Block 1346406 on DFSCluster")
-	// create input directory
-   dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
-	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
-	// copy bitcoin blocks
-	val classLoader = getClass.getClassLoader
-    	// put testdata on DFS
-    	val fileName: String="eth1346406.bin"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile
-    	val inputFile=new Path(fileNameFullLocal)
-    	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
-	When("reading block 1346406 using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.ethereum.block").option("useDirectBuffer", "false").load(dfsCluster.getFileSystem().getUri.toString+DFS_INPUT_DIR_NAME)
-	Then("all fields should be readable trough Spark SQL")
-	// check first if structure is correct
-	assert("ethereumBlockHeader"==df.columns(0))
-	assert("ethereumTransactions"==df.columns(1))
-	assert("uncleHeaders"==df.columns(2))
+  "The block 1346406 on DFS" should "be fully read in dataframe" in {
+    Given("Block 1346406 on DFSCluster")
+    // create input directory
+    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR, true)
+    dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
+    // copy bitcoin blocks
+    val classLoader = getClass.getClassLoader
+    // put testdata on DFS
+    val fileName: String = "eth1346406.bin"
+    val fileNameFullLocal = classLoader.getResource("testdata/" + fileName).getFile
+    val inputFile = new Path(fileNameFullLocal)
+    dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
+    When("reading block 1346406 using datasource")
+    val df = sqlContext.read.format("org.zuinnote.spark.ethereum.block").option("useDirectBuffer", "false").load(dfsCluster.getFileSystem().getUri.toString + DFS_INPUT_DIR_NAME)
+    Then("all fields should be readable trough Spark SQL")
+    // check first if structure is correct
+    assert("ethereumBlockHeader" == df.columns(0))
+    assert("ethereumTransactions" == df.columns(1))
+    assert("uncleHeaders" == df.columns(2))
 
     val ethereumTransactionsDF = df.select(explode(df("ethereumTransactions")).alias("ethereumTransactions"))
     val ethereumUncleHeaderDF = df.select(explode(df("uncleHeaders")).alias("uncleHeaders"))
@@ -177,9 +171,9 @@ class SparkEthereumBlockDSSparkMasterIntegrationSpec extends FlatSpec with Befor
     val expectedBhDifficulty = Array(0x19.toByte, 0xFF.toByte, 0x9E.toByte, 0xC4.toByte, 0x35.toByte, 0xE0.toByte)
     val bhDifficulty = df.select("ethereumBlockHeader.difficulty").collect
     assert(expectedBhDifficulty.deep == bhDifficulty(0).get(0).asInstanceOf[Array[Byte]].deep)
-    val format = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z")
-    val expectedDTStr = "16-04-2016 09:34:29 UTC"
-    val expectedBhTimestamp = format.parse(expectedDTStr).getTime / 1000
+    val format = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z");
+    val expectedDTStr = "16-04-2016 09:34:29 UTC";
+    val expectedBhTimestamp = format.parse(expectedDTStr).getTime / 1000;
     val bhTimestamp = df.select("ethereumBlockHeader.timestamp").collect
     assert(expectedBhTimestamp == bhTimestamp(0).get(0))
     val expectedBhNumber = 1346406
@@ -327,214 +321,216 @@ class SparkEthereumBlockDSSparkMasterIntegrationSpec extends FlatSpec with Befor
 
     // uncle headers
     // block does not contain uncleheaders
-}
 
-"The block 1346406 on DFS" should "be fully read in dataframe (with rich data types)" in {
-	Given("Block 1346406 on DFSCluster")
-	// create input directory
-   dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
-	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
-	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
-    	// put testdata on DFS
-    	val fileName: String="eth1346406.bin"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
-    	val inputFile=new Path(fileNameFullLocal)
-    	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
-	When("reading block 1346406 using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.ethereum.block").option("useDirectBuffer", "false").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
-	Then("all fields should be readable trough Spark SQL")
-	// check first if structure is correct
-	assert("ethereumBlockHeader"==df.columns(0))
-	assert("ethereumTransactions"==df.columns(1))
-	assert("uncleHeaders"==df.columns(2))
+  }
 
-  val ethereumTransactionsDF = df.select(explode(df("ethereumTransactions")).alias("ethereumTransactions"))
+  "The block 1346406 on DFS" should "be fully read in dataframe (with rich data types)" in {
+    Given("Block 1346406 on DFSCluster")
+    // create input directory
+    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR, true)
+    dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
+    // copy bitcoin blocks
+    val classLoader = getClass.getClassLoader
+    // put testdata on DFS
+    val fileName: String = "eth1346406.bin"
+    val fileNameFullLocal = classLoader.getResource("testdata/" + fileName).getFile
+    val inputFile = new Path(fileNameFullLocal)
+    dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
+    When("reading block 1346406 using datasource")
+    val df = sqlContext.read.format("org.zuinnote.spark.ethereum.block").option("useDirectBuffer", "false").load(dfsCluster.getFileSystem().getUri.toString + DFS_INPUT_DIR_NAME)
+    Then("all fields should be readable trough Spark SQL")
+    // check first if structure is correct
+    assert("ethereumBlockHeader" == df.columns(0))
+    assert("ethereumTransactions" == df.columns(1))
+    assert("uncleHeaders" == df.columns(2))
+
+    val ethereumTransactionsDF = df.select(explode(df("ethereumTransactions")).alias("ethereumTransactions"))
     val ethereumUncleHeaderDF = df.select(explode(df("uncleHeaders")).alias("uncleHeaders"))
-  // check if content is correct
-  // sanity checks
-  assert(6==ethereumTransactionsDF.count())
-  assert(0==ethereumUncleHeaderDF.count())
-  // check details
-  // block header
-  val expectedBhParentHash = Array(0xba.toByte,0x6d.toByte,0xd2.toByte,0x60.toByte,0x12.toByte,0xb3.toByte,0x71.toByte,0x90.toByte,0x48.toByte,0xf3.toByte,0x16.toByte,0xc6.toByte,0xed.toByte,0xb3.toByte,0x34.toByte,0x9b.toByte,0xdf.toByte,0xbd.toByte,0x61.toByte,0x31.toByte,0x9f.toByte,0xa9.toByte,0x7c.toByte,0x61.toByte,0x6a.toByte,0x61.toByte,0x31.toByte,0x18.toByte,0xa1.toByte,0xaf.toByte,0x30.toByte,0x67.toByte)
-  val bhParentHash = df.select("ethereumBlockHeader.parentHash").collect
-  assert(expectedBhParentHash.deep==bhParentHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectdBhUncleHash = Array(0x1D.toByte,0xCC.toByte,0x4D.toByte,0xE8.toByte,0xDE.toByte,0xC7.toByte,0x5D.toByte,0x7A.toByte,0xAB.toByte,0x85.toByte,0xB5.toByte,0x67.toByte,0xB6.toByte,0xCC.toByte,0xD4.toByte,0x1A.toByte,0xD3.toByte,0x12.toByte,0x45.toByte,0x1B.toByte,0x94.toByte,0x8A.toByte,0x74.toByte,0x13.toByte,0xF0.toByte,0xA1.toByte,0x42.toByte,0xFD.toByte,0x40.toByte,0xD4.toByte,0x93.toByte,0x47.toByte)
-  val bhUncleHash = df.select("ethereumBlockHeader.uncleHash").collect
-  assert(expectdBhUncleHash.deep==bhUncleHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhCoinBase = Array(0x1A.toByte,0x06.toByte,0x0B.toByte,0x06.toByte,0x04.toByte,0x88.toByte,0x3A.toByte,0x99.toByte,0x80.toByte,0x9E.toByte,0xB3.toByte,0xF7.toByte,0x98.toByte,0xDF.toByte,0x71.toByte,0xBE.toByte,0xF6.toByte,0xC3.toByte,0x58.toByte,0xF1.toByte)
-  val bhCoinBase = df.select("ethereumBlockHeader.coinBase").collect
-  assert(expectedBhCoinBase.deep==bhCoinBase(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhStateRoot = Array(0x21.toByte,0xBA.toByte,0x88.toByte,0x6F.toByte,0xD2.toByte,0x6F.toByte,0x17.toByte,0xB4.toByte,0x01.toByte,0xF5.toByte,0x39.toByte,0x20.toByte,0x15.toByte,0x33.toByte,0x10.toByte,0xB6.toByte,0x93.toByte,0x9B.toByte,0xAD.toByte,0x8A.toByte,0x5F.toByte,0xC3.toByte,0xBF.toByte,0x8C.toByte,0x50.toByte,0x5C.toByte,0x55.toByte,0x6D.toByte,0xDB.toByte,0xAF.toByte,0xBC.toByte,0x5C.toByte)
-  val bhStateRoot = df.select("ethereumBlockHeader.stateRoot").collect
-  assert(expectedBhStateRoot.deep==bhStateRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhTxTrieRoot = Array(0xB3.toByte,0xCB.toByte,0xC7.toByte,0xF0.toByte,0xD7.toByte,0x87.toByte,0xE5.toByte,0x7D.toByte,0x93.toByte,0x70.toByte,0xB8.toByte,0x02.toByte,0xAB.toByte,0x94.toByte,0x5E.toByte,0x21.toByte,0x99.toByte,0x1C.toByte,0x3E.toByte,0x12.toByte,0x7D.toByte,0x70.toByte,0x12.toByte,0x0C.toByte,0x37.toByte,0xE9.toByte,0xFD.toByte,0xAE.toByte,0x3E.toByte,0xF3.toByte,0xEB.toByte,0xFC.toByte)
-  val bhTxTrieRoot = df.select("ethereumBlockHeader.txTrieRoot").collect
-  assert(expectedBhTxTrieRoot.deep==bhTxTrieRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhReceiptTrieRoot = Array(0x9B.toByte,0xCE.toByte,0x71.toByte,0x32.toByte,0xF5.toByte,0x2D.toByte,0x4D.toByte,0x45.toByte,0xA8.toByte,0xA2.toByte,0x47.toByte,0x48.toByte,0x47.toByte,0x86.toByte,0xC7.toByte,0x0B.toByte,0xB2.toByte,0xE6.toByte,0x39.toByte,0x59.toByte,0xC8.toByte,0x56.toByte,0x1B.toByte,0x3A.toByte,0xBF.toByte,0xD4.toByte,0xE7.toByte,0x22.toByte,0xE6.toByte,0x00.toByte,0x6A.toByte,0x27.toByte)
-  val bhReceiptTrieRoot = df.select("ethereumBlockHeader.receiptTrieRoot").collect
-  assert(expectedBhReceiptTrieRoot.deep==bhReceiptTrieRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhLogsBloom = Array(0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte)
-  val bhLogsBloom = df.select("ethereumBlockHeader.logsBloom").collect
-  assert(expectedBhLogsBloom.deep==bhLogsBloom(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhDifficulty = Array(0x19.toByte,0xFF.toByte,0x9E.toByte,0xC4.toByte,0x35.toByte,0xE0.toByte)
-  val bhDifficulty = df.select("ethereumBlockHeader.difficulty").collect
-  assert(expectedBhDifficulty.deep==bhDifficulty(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val format = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z");
-	val expectedDTStr = "16-04-2016 09:34:29 UTC";
-  val expectedBhTimestamp = format.parse(expectedDTStr).getTime() / 1000;
-  val bhTimestamp = df.select("ethereumBlockHeader.timestamp").collect
-  assert(expectedBhTimestamp==bhTimestamp(0).get(0))
-  val expectedBhNumber = 1346406
-  val bhNumber = df.select("ethereumBlockHeader.number").collect
-  assert(expectedBhNumber==bhNumber(0).get(0))
-  val expectedBhGasLimit = 4712388
-  val bhGasLimit = df.select("ethereumBlockHeader.gasLimit").collect
-  assert(expectedBhGasLimit==bhGasLimit(0).get(0))
-  val expectedBhGasUsed = 126000
-  val bhGasUsed = df.select("ethereumBlockHeader.gasUsed").collect
-  assert(expectedBhGasUsed==bhGasUsed(0).get(0))
-  val expectedBhMixHash = Array(0x4F.toByte,0x57.toByte,0x71.toByte,0xB7.toByte,0x9A.toByte,0x8E.toByte,0x6E.toByte,0x21.toByte,0x99.toByte,0x35.toByte,0x53.toByte,0x9C.toByte,0x47.toByte,0x3E.toByte,0x23.toByte,0xBA.toByte,0xFD.toByte,0x2C.toByte,0xA3.toByte,0x5C.toByte,0xC1.toByte,0x86.toByte,0x20.toByte,0x66.toByte,0x31.toByte,0xC3.toByte,0xB0.toByte,0x9E.toByte,0xD5.toByte,0x76.toByte,0x19.toByte,0x4A.toByte)
-  val bhMixHash = df.select("ethereumBlockHeader.mixHash").collect
-  assert(expectedBhMixHash.deep==bhMixHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhExtraData = Array(0xD7.toByte,0x83.toByte,0x01.toByte,0x03.toByte,0x05.toByte,0x84.toByte,0x47.toByte,0x65.toByte,0x74.toByte,0x68.toByte,0x87.toByte,0x67.toByte,0x6F.toByte,0x31.toByte,0x2E.toByte,0x35.toByte,0x2E.toByte,0x31.toByte,0x85.toByte,0x6C.toByte,0x69.toByte,0x6E.toByte,0x75.toByte,0x78.toByte)
-  val bhExtraData = df.select("ethereumBlockHeader.extraData").collect
-    assert(expectedBhExtraData.deep==bhExtraData(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhNonce = Array(0xFF.toByte,0x7C.toByte,0x7A.toByte,0xEE.toByte,0x0E.toByte,0x88.toByte,0xC5.toByte,0x2D.toByte)
-  val bhNonce = df.select("ethereumBlockHeader.nonce").collect
-    assert(expectedBhNonce.deep==bhNonce(0).get(0).asInstanceOf[Array[Byte]].deep)
-  // transactions
-  val tnonces = ethereumTransactionsDF.select("ethereumTransactions.nonce").collect
-  val tvalues = ethereumTransactionsDF.select("ethereumTransactions.value").collect
-  val treceiveAddresses = ethereumTransactionsDF.select("ethereumTransactions.receiveAddress").collect
-  val tgasPrices = ethereumTransactionsDF.select("ethereumTransactions.gasPrice").collect
-  val tgasLimits = ethereumTransactionsDF.select("ethereumTransactions.gasLimit").collect
-  val tdatas = ethereumTransactionsDF.select("ethereumTransactions.data").collect
-  val tsigvs = ethereumTransactionsDF.select("ethereumTransactions.sig_v").collect
-  val tsigrs = ethereumTransactionsDF.select("ethereumTransactions.sig_r").collect
-  val tsigss = ethereumTransactionsDF.select("ethereumTransactions.sig_s").collect
-  var transactNum=0
-  val expectedt1Nonce = Array(0x0C.toByte)
-  assert(expectedt1Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1Value = 1069000990000000000L
-  assert(expectedt1Value==tvalues(transactNum).get(0))
-  val expectedt1ReceiveAddress= Array(0x1E.toByte,0x75.toByte,0xF0.toByte,0x2A.toByte,0x6E.toByte,0x9F.toByte,0xF4.toByte,0xFF.toByte,0x16.toByte,0x33.toByte,0x38.toByte,0x25.toByte,0xD9.toByte,0x09.toByte,0xBB.toByte,0x03.toByte,0x33.toByte,0x06.toByte,0xB7.toByte,0x8B.toByte)
-  assert(expectedt1ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1GasPrice=20000000000L
-  assert(expectedt1GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt1GasLimit=21000
-  assert(expectedt1GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt1Data : Array[Byte] = Array()
-  assert(expectedt1Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1sigv = Array(0x1B.toByte)
-  assert(expectedt1sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1sigr = Array(0x47.toByte,0xDD.toByte,0xF9.toByte,0x37.toByte,0x68.toByte,0x97.toByte,0x76.toByte,0x78.toByte,0x13.toByte,0x95.toByte,0x5A.toByte,0x9D.toByte,0x46.toByte,0xB6.toByte,0xF1.toByte,0xAA.toByte,0x77.toByte,0x73.toByte,0xE5.toByte,0xC8.toByte,0xC6.toByte,0x21.toByte,0x67.toByte,0x54.toByte,0x1C.toByte,0x80.toByte,0xBF.toByte,0x25.toByte,0x2D.toByte,0xC7.toByte,0xDC.toByte,0xD2.toByte)
-  assert(expectedt1sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1sigs = Array(0x0A.toByte,0x31.toByte,0x3F.toByte,0x35.toByte,0x60.toByte,0x32.toByte,0x37.toByte,0x56.toByte,0xB7.toByte,0x28.toByte,0x5F.toByte,0x62.toByte,0x38.toByte,0x51.toByte,0x86.toByte,0x05.toByte,0x82.toByte,0x1A.toByte,0x2B.toByte,0xEE.toByte,0x03.toByte,0x7D.toByte,0xEA.toByte,0x8F.toByte,0x09.toByte,0x22.toByte,0x66.toByte,0x20.toByte,0x89.toByte,0x03.toByte,0x74.toByte,0x59.toByte)
-  assert(expectedt1sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  transactNum=1
-  val expectedt2Nonce = Array(0xFF.toByte,0xD7.toByte)
-  assert(expectedt2Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2Value = 5110508700000000000L
-  assert(expectedt2Value==tvalues(transactNum).get(0))
-  val expectedt2ReceiveAddress= Array(0x54.toByte,0x67.toByte,0xFA.toByte,0xBD.toByte,0x30.toByte,0xEB.toByte,0x61.toByte,0xA1.toByte,0x84.toByte,0x61.toByte,0xD1.toByte,0x53.toByte,0xD8.toByte,0xC6.toByte,0xFF.toByte,0xB1.toByte,0x9D.toByte,0xD4.toByte,0x7A.toByte,0x25.toByte)
-  assert(expectedt2ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2GasPrice=20000000000L
-  assert(expectedt2GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt2GasLimit=90000
-  assert(expectedt2GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt2Data : Array[Byte] = Array()
-  assert(expectedt2Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2sigv = Array(0x1B.toByte)
-  assert(expectedt2sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2sigr = Array(0x62.toByte,0x85.toByte,0x3C.toByte,0x63.toByte,0x9A.toByte,0x9B.toByte,0x9E.toByte,0xC4.toByte,0x9B.toByte,0xA9.toByte,0xAC.toByte,0x53.toByte,0xE2.toByte,0x85.toByte,0xB3.toByte,0x4E.toByte,0xD0.toByte,0xB7.toByte,0x65.toByte,0x5C.toByte,0x1B.toByte,0xE3.toByte,0x29.toByte,0xFB.toByte,0x8B.toByte,0x34.toByte,0x70.toByte,0x74.toByte,0x0C.toByte,0x3D.toByte,0x0A.toByte,0x9A.toByte)
-   assert(expectedt2sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2sigs =  Array(0x03.toByte,0xFA.toByte,0xA6.toByte,0xF4.toByte,0xFF.toByte,0x1A.toByte,0x45.toByte,0x76.toByte,0xDF.toByte,0x08.toByte,0x9A.toByte,0x9F.toByte,0x9C.toByte,0xB7.toByte,0x9C.toByte,0xF2.toByte,0xED.toByte,0xC1.toByte,0xC5.toByte,0xBD.toByte,0xEC.toByte,0x0F.toByte,0xE7.toByte,0x9C.toByte,0x79.toByte,0x2A.toByte,0xCB.toByte,0x9E.toByte,0x83.toByte,0xF2.toByte,0x41.toByte)
-  assert(expectedt2sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  transactNum=2
-  val expectedt3Nonce = Array(0x02.toByte,0xD7.toByte,0xDD.toByte)
-  assert(expectedt3Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3Value = 11667800000000000L
-  assert(expectedt3Value==tvalues(transactNum).get(0))
-  val expectedt3ReceiveAddress= Array(0xB4.toByte,0xD0.toByte,0xCA.toByte,0x2B.toByte,0x7E.toByte,0x4C.toByte,0xB1.toByte,0xE0.toByte,0x61.toByte,0x0D.toByte,0x02.toByte,0x15.toByte,0x4A.toByte,0x10.toByte,0x16.toByte,0x3A.toByte,0xB0.toByte,0xF4.toByte,0x2E.toByte,0x65.toByte)
-     assert(expectedt3ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3GasPrice=20000000000L
-  assert(expectedt3GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt3GasLimit=90000
-  assert(expectedt3GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt3Data : Array[Byte] = Array()
-  assert(expectedt3Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3sigv = Array(0x1C.toByte)
-  assert(expectedt3sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3sigr = Array(0x89.toByte,0xFD.toByte,0x7A.toByte,0x62.toByte,0xCF.toByte,0x44.toByte,0x77.toByte,0xBF.toByte,0xE5.toByte,0xDB.toByte,0xF0.toByte,0xEE.toByte,0xCF.toByte,0x3A.toByte,0x4A.toByte,0x96.toByte,0x71.toByte,0x96.toByte,0x96.toByte,0xFB.toByte,0xBE.toByte,0x16.toByte,0xBA.toByte,0x0A.toByte,0xBA.toByte,0x1D.toByte,0x63.toByte,0x1D.toByte,0x44.toByte,0xC1.toByte,0xEB.toByte,0x58.toByte)
-   assert(expectedt3sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3sigs =  Array(0x24.toByte,0x34.toByte,0x48.toByte,0x64.toByte,0xEB.toByte,0x6A.toByte,0x60.toByte,0xC6.toByte,0x6F.toByte,0xB5.toByte,0xDA.toByte,0xED.toByte,0x02.toByte,0xB5.toByte,0x63.toByte,0x52.toByte,0xE8.toByte,0x17.toByte,0x42.toByte,0x16.toByte,0xB8.toByte,0xA2.toByte,0xD3.toByte,0x33.toByte,0xB7.toByte,0xF3.toByte,0x32.toByte,0xFF.toByte,0x6B.toByte,0xA0.toByte,0x69.toByte,0x9C.toByte)
-  assert(expectedt3sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  transactNum=3
-  val expectedt4Nonce = Array(0x02.toByte,0xD7.toByte,0xDE.toByte)
-  assert(expectedt4Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4Value = 130970170000000000L
-  assert(expectedt4Value==tvalues(transactNum).get(0))
-  val expectedt4ReceiveAddress= Array(0x1F.toByte,0x57.toByte,0xF8.toByte,0x26.toByte,0xCA.toByte,0xF5.toByte,0x94.toByte,0xF7.toByte,0xA8.toByte,0x37.toByte,0xD9.toByte,0xFC.toByte,0x09.toByte,0x24.toByte,0x56.toByte,0x87.toByte,0x0A.toByte,0x28.toByte,0x93.toByte,0x65.toByte)
-     assert(expectedt4ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4GasPrice=20000000000L
-  assert(expectedt4GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt4GasLimit=90000
-  assert(expectedt4GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt4Data : Array[Byte] = Array()
-  assert(expectedt4Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4sigv = Array(0x1B.toByte)
-  assert(expectedt4sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4sigr = Array(0x46.toByte,0x01.toByte,0x57.toByte,0xDC.toByte,0xE4.toByte,0xE9.toByte,0x5D.toByte,0x1D.toByte,0xCC.toByte,0x7A.toByte,0xED.toByte,0x0D.toByte,0x9B.toByte,0x7E.toByte,0x3D.toByte,0x65.toByte,0x37.toByte,0x0C.toByte,0x53.toByte,0xD2.toByte,0x9E.toByte,0xA9.toByte,0xB1.toByte,0xAA.toByte,0x4C.toByte,0x9C.toByte,0x22.toByte,0x14.toByte,0x91.toByte,0x1C.toByte,0xD9.toByte,0x5E.toByte)
-    assert(expectedt4sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4sigs = Array(0x6A.toByte,0x84.toByte,0x4F.toByte,0x95.toByte,0x6D.toByte,0x02.toByte,0x46.toByte,0x94.toByte,0x1B.toByte,0x94.toByte,0x30.toByte,0x91.toByte,0x34.toByte,0x21.toByte,0x20.toByte,0xBD.toByte,0x48.toByte,0xE7.toByte,0xC6.toByte,0x35.toByte,0x77.toByte,0xF0.toByte,0xBA.toByte,0x3D.toByte,0x87.toByte,0x59.toByte,0xC9.toByte,0xEC.toByte,0x58.toByte,0x70.toByte,0x4E.toByte,0xEC.toByte)
-    assert(expectedt4sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  transactNum=4
-  val expectedt5Nonce = Array(0x02.toByte,0xD7.toByte,0xDF.toByte)
-  assert(expectedt5Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5Value = 144683800000000000L
-  assert(expectedt5Value==tvalues(transactNum).get(0))
-  val expectedt5ReceiveAddress= Array(0x1F.toByte,0x57.toByte,0xF8.toByte,0x26.toByte,0xCA.toByte,0xF5.toByte,0x94.toByte,0xF7.toByte,0xA8.toByte,0x37.toByte,0xD9.toByte,0xFC.toByte,0x09.toByte,0x24.toByte,0x56.toByte,0x87.toByte,0x0A.toByte,0x28.toByte,0x93.toByte,0x65.toByte)
-assert(expectedt5ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5GasPrice=20000000000L
-  assert(expectedt5GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt5GasLimit=90000
-  assert(expectedt5GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt5Data : Array[Byte] = Array()
-  assert(expectedt5Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5sigv = Array(0x1C.toByte)
-  assert(expectedt5sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5sigr = Array(0xE4.toByte,0xBE.toByte,0x97.toByte,0xD5.toByte,0xAF.toByte,0xF1.toByte,0xB5.toByte,0xE7.toByte,0x99.toByte,0x12.toByte,0x96.toByte,0x98.toByte,0x2B.toByte,0xDF.toByte,0xC1.toByte,0xC2.toByte,0x2F.toByte,0x75.toByte,0x21.toByte,0x13.toByte,0x4F.toByte,0x7E.toByte,0x1A.toByte,0x9D.toByte,0xA3.toByte,0x00.toByte,0x42.toByte,0x0D.toByte,0xAD.toByte,0x33.toByte,0x6F.toByte,0x34.toByte)
-    assert(expectedt5sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5sigs = Array(0x62.toByte,0xDE.toByte,0xF8.toByte,0xAA.toByte,0x83.toByte,0x65.toByte,0x58.toByte,0xC7.toByte,0xB0.toByte,0xA5.toByte,0x65.toByte,0xB9.toByte,0x7C.toByte,0x9B.toByte,0x27.toByte,0xB2.toByte,0x0E.toByte,0xD9.toByte,0xA0.toByte,0x51.toByte,0xDE.toByte,0x22.toByte,0xAD.toByte,0x8D.toByte,0xBD.toByte,0x62.toByte,0x52.toByte,0x44.toByte,0xCE.toByte,0x64.toByte,0x9E.toByte,0x3D.toByte)
-     assert(expectedt5sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  transactNum=5
-  val expectedt6Nonce =  Array(0x02.toByte,0xD7.toByte,0xE0.toByte)
-  assert(expectedt6Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6Value = 143694920000000000L
-  assert(expectedt6Value==tvalues(transactNum).get(0))
-  val expectedt6ReceiveAddress= Array(0x1F.toByte,0x57.toByte,0xF8.toByte,0x26.toByte,0xCA.toByte,0xF5.toByte,0x94.toByte,0xF7.toByte,0xA8.toByte,0x37.toByte,0xD9.toByte,0xFC.toByte,0x09.toByte,0x24.toByte,0x56.toByte,0x87.toByte,0x0A.toByte,0x28.toByte,0x93.toByte,0x65.toByte)
-    assert(expectedt6ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6GasPrice=20000000000L
-  assert(expectedt6GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt6GasLimit=90000
-  assert(expectedt6GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt6Data : Array[Byte] = Array()
-  assert(expectedt6Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6sigv = Array(0x1C.toByte)
-  assert(expectedt6sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6sigr = Array(0x0A.toByte,0x4C.toByte,0xA2.toByte,0x18.toByte,0x46.toByte,0x0D.toByte,0xC8.toByte,0x5B.toByte,0x99.toByte,0x07.toByte,0x46.toByte,0xFB.toByte,0xB9.toByte,0x0C.toByte,0x06.toByte,0xF8.toByte,0x25.toByte,0x87.toByte,0x82.toByte,0x80.toByte,0x87.toByte,0x27.toByte,0x98.toByte,0x3C.toByte,0x8B.toByte,0x8D.toByte,0x6A.toByte,0x92.toByte,0x1E.toByte,0x19.toByte,0x9B.toByte,0xCA.toByte)
-   assert(expectedt6sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6sigs = Array(0x08.toByte,0xA3.toByte,0xB9.toByte,0xA4.toByte,0x5D.toByte,0x83.toByte,0x1A.toByte,0xC4.toByte,0xAD.toByte,0x37.toByte,0x9D.toByte,0x14.toByte,0xF0.toByte,0xAE.toByte,0x3C.toByte,0x03.toByte,0xC8.toByte,0x73.toByte,0x1C.toByte,0xB4.toByte,0x4D.toByte,0x8A.toByte,0x79.toByte,0xAC.toByte,0xD4.toByte,0xCD.toByte,0x6C.toByte,0xEA.toByte,0x1B.toByte,0x54.toByte,0x80.toByte,0x02.toByte)
-  assert(expectedt6sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    // check if content is correct
+    // sanity checks
+    assert(6 == ethereumTransactionsDF.count())
+    assert(0 == ethereumUncleHeaderDF.count())
+    // check details
+    // block header
+    val expectedBhParentHash = Array(0xba.toByte, 0x6d.toByte, 0xd2.toByte, 0x60.toByte, 0x12.toByte, 0xb3.toByte, 0x71.toByte, 0x90.toByte, 0x48.toByte, 0xf3.toByte, 0x16.toByte, 0xc6.toByte, 0xed.toByte, 0xb3.toByte, 0x34.toByte, 0x9b.toByte, 0xdf.toByte, 0xbd.toByte, 0x61.toByte, 0x31.toByte, 0x9f.toByte, 0xa9.toByte, 0x7c.toByte, 0x61.toByte, 0x6a.toByte, 0x61.toByte, 0x31.toByte, 0x18.toByte, 0xa1.toByte, 0xaf.toByte, 0x30.toByte, 0x67.toByte)
+    val bhParentHash = df.select("ethereumBlockHeader.parentHash").collect
+    assert(expectedBhParentHash.deep == bhParentHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectdBhUncleHash = Array(0x1D.toByte, 0xCC.toByte, 0x4D.toByte, 0xE8.toByte, 0xDE.toByte, 0xC7.toByte, 0x5D.toByte, 0x7A.toByte, 0xAB.toByte, 0x85.toByte, 0xB5.toByte, 0x67.toByte, 0xB6.toByte, 0xCC.toByte, 0xD4.toByte, 0x1A.toByte, 0xD3.toByte, 0x12.toByte, 0x45.toByte, 0x1B.toByte, 0x94.toByte, 0x8A.toByte, 0x74.toByte, 0x13.toByte, 0xF0.toByte, 0xA1.toByte, 0x42.toByte, 0xFD.toByte, 0x40.toByte, 0xD4.toByte, 0x93.toByte, 0x47.toByte)
+    val bhUncleHash = df.select("ethereumBlockHeader.uncleHash").collect
+    assert(expectdBhUncleHash.deep == bhUncleHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhCoinBase = Array(0x1A.toByte, 0x06.toByte, 0x0B.toByte, 0x06.toByte, 0x04.toByte, 0x88.toByte, 0x3A.toByte, 0x99.toByte, 0x80.toByte, 0x9E.toByte, 0xB3.toByte, 0xF7.toByte, 0x98.toByte, 0xDF.toByte, 0x71.toByte, 0xBE.toByte, 0xF6.toByte, 0xC3.toByte, 0x58.toByte, 0xF1.toByte)
+    val bhCoinBase = df.select("ethereumBlockHeader.coinBase").collect
+    assert(expectedBhCoinBase.deep == bhCoinBase(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhStateRoot = Array(0x21.toByte, 0xBA.toByte, 0x88.toByte, 0x6F.toByte, 0xD2.toByte, 0x6F.toByte, 0x17.toByte, 0xB4.toByte, 0x01.toByte, 0xF5.toByte, 0x39.toByte, 0x20.toByte, 0x15.toByte, 0x33.toByte, 0x10.toByte, 0xB6.toByte, 0x93.toByte, 0x9B.toByte, 0xAD.toByte, 0x8A.toByte, 0x5F.toByte, 0xC3.toByte, 0xBF.toByte, 0x8C.toByte, 0x50.toByte, 0x5C.toByte, 0x55.toByte, 0x6D.toByte, 0xDB.toByte, 0xAF.toByte, 0xBC.toByte, 0x5C.toByte)
+    val bhStateRoot = df.select("ethereumBlockHeader.stateRoot").collect
+    assert(expectedBhStateRoot.deep == bhStateRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhTxTrieRoot = Array(0xB3.toByte, 0xCB.toByte, 0xC7.toByte, 0xF0.toByte, 0xD7.toByte, 0x87.toByte, 0xE5.toByte, 0x7D.toByte, 0x93.toByte, 0x70.toByte, 0xB8.toByte, 0x02.toByte, 0xAB.toByte, 0x94.toByte, 0x5E.toByte, 0x21.toByte, 0x99.toByte, 0x1C.toByte, 0x3E.toByte, 0x12.toByte, 0x7D.toByte, 0x70.toByte, 0x12.toByte, 0x0C.toByte, 0x37.toByte, 0xE9.toByte, 0xFD.toByte, 0xAE.toByte, 0x3E.toByte, 0xF3.toByte, 0xEB.toByte, 0xFC.toByte)
+    val bhTxTrieRoot = df.select("ethereumBlockHeader.txTrieRoot").collect
+    assert(expectedBhTxTrieRoot.deep == bhTxTrieRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhReceiptTrieRoot = Array(0x9B.toByte, 0xCE.toByte, 0x71.toByte, 0x32.toByte, 0xF5.toByte, 0x2D.toByte, 0x4D.toByte, 0x45.toByte, 0xA8.toByte, 0xA2.toByte, 0x47.toByte, 0x48.toByte, 0x47.toByte, 0x86.toByte, 0xC7.toByte, 0x0B.toByte, 0xB2.toByte, 0xE6.toByte, 0x39.toByte, 0x59.toByte, 0xC8.toByte, 0x56.toByte, 0x1B.toByte, 0x3A.toByte, 0xBF.toByte, 0xD4.toByte, 0xE7.toByte, 0x22.toByte, 0xE6.toByte, 0x00.toByte, 0x6A.toByte, 0x27.toByte)
+    val bhReceiptTrieRoot = df.select("ethereumBlockHeader.receiptTrieRoot").collect
+    assert(expectedBhReceiptTrieRoot.deep == bhReceiptTrieRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhLogsBloom = Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)
+    val bhLogsBloom = df.select("ethereumBlockHeader.logsBloom").collect
+    assert(expectedBhLogsBloom.deep == bhLogsBloom(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhDifficulty = Array(0x19.toByte, 0xFF.toByte, 0x9E.toByte, 0xC4.toByte, 0x35.toByte, 0xE0.toByte)
+    val bhDifficulty = df.select("ethereumBlockHeader.difficulty").collect
+    assert(expectedBhDifficulty.deep == bhDifficulty(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val format = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z");
+    val expectedDTStr = "16-04-2016 09:34:29 UTC";
+    val expectedBhTimestamp = format.parse(expectedDTStr).getTime / 1000;
+    val bhTimestamp = df.select("ethereumBlockHeader.timestamp").collect
+    assert(expectedBhTimestamp == bhTimestamp(0).get(0))
+    val expectedBhNumber = 1346406
+    val bhNumber = df.select("ethereumBlockHeader.number").collect
+    assert(expectedBhNumber == bhNumber(0).get(0))
+    val expectedBhGasLimit = 4712388
+    val bhGasLimit = df.select("ethereumBlockHeader.gasLimit").collect
+    assert(expectedBhGasLimit == bhGasLimit(0).get(0))
+    val expectedBhGasUsed = 126000
+    val bhGasUsed = df.select("ethereumBlockHeader.gasUsed").collect
+    assert(expectedBhGasUsed == bhGasUsed(0).get(0))
+    val expectedBhMixHash = Array(0x4F.toByte, 0x57.toByte, 0x71.toByte, 0xB7.toByte, 0x9A.toByte, 0x8E.toByte, 0x6E.toByte, 0x21.toByte, 0x99.toByte, 0x35.toByte, 0x53.toByte, 0x9C.toByte, 0x47.toByte, 0x3E.toByte, 0x23.toByte, 0xBA.toByte, 0xFD.toByte, 0x2C.toByte, 0xA3.toByte, 0x5C.toByte, 0xC1.toByte, 0x86.toByte, 0x20.toByte, 0x66.toByte, 0x31.toByte, 0xC3.toByte, 0xB0.toByte, 0x9E.toByte, 0xD5.toByte, 0x76.toByte, 0x19.toByte, 0x4A.toByte)
+    val bhMixHash = df.select("ethereumBlockHeader.mixHash").collect
+    assert(expectedBhMixHash.deep == bhMixHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhExtraData = Array(0xD7.toByte, 0x83.toByte, 0x01.toByte, 0x03.toByte, 0x05.toByte, 0x84.toByte, 0x47.toByte, 0x65.toByte, 0x74.toByte, 0x68.toByte, 0x87.toByte, 0x67.toByte, 0x6F.toByte, 0x31.toByte, 0x2E.toByte, 0x35.toByte, 0x2E.toByte, 0x31.toByte, 0x85.toByte, 0x6C.toByte, 0x69.toByte, 0x6E.toByte, 0x75.toByte, 0x78.toByte)
+    val bhExtraData = df.select("ethereumBlockHeader.extraData").collect
+    assert(expectedBhExtraData.deep == bhExtraData(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhNonce = Array(0xFF.toByte, 0x7C.toByte, 0x7A.toByte, 0xEE.toByte, 0x0E.toByte, 0x88.toByte, 0xC5.toByte, 0x2D.toByte)
+    val bhNonce = df.select("ethereumBlockHeader.nonce").collect
+    assert(expectedBhNonce.deep == bhNonce(0).get(0).asInstanceOf[Array[Byte]].deep)
+    // transactions
+    val tnonces = ethereumTransactionsDF.select("ethereumTransactions.nonce").collect
+    val tvalues = ethereumTransactionsDF.select("ethereumTransactions.value").collect
+    val treceiveAddresses = ethereumTransactionsDF.select("ethereumTransactions.receiveAddress").collect
+    val tgasPrices = ethereumTransactionsDF.select("ethereumTransactions.gasPrice").collect
+    val tgasLimits = ethereumTransactionsDF.select("ethereumTransactions.gasLimit").collect
+    val tdatas = ethereumTransactionsDF.select("ethereumTransactions.data").collect
+    val tsigvs = ethereumTransactionsDF.select("ethereumTransactions.sig_v").collect
+    val tsigrs = ethereumTransactionsDF.select("ethereumTransactions.sig_r").collect
+    val tsigss = ethereumTransactionsDF.select("ethereumTransactions.sig_s").collect
+    var transactNum = 0
+    val expectedt1Nonce = Array(0x0C.toByte)
+    assert(expectedt1Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1Value = 1069000990000000000L
+    assert(expectedt1Value == tvalues(transactNum).get(0))
+    val expectedt1ReceiveAddress = Array(0x1E.toByte, 0x75.toByte, 0xF0.toByte, 0x2A.toByte, 0x6E.toByte, 0x9F.toByte, 0xF4.toByte, 0xFF.toByte, 0x16.toByte, 0x33.toByte, 0x38.toByte, 0x25.toByte, 0xD9.toByte, 0x09.toByte, 0xBB.toByte, 0x03.toByte, 0x33.toByte, 0x06.toByte, 0xB7.toByte, 0x8B.toByte)
+    assert(expectedt1ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1GasPrice = 20000000000L
+    assert(expectedt1GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt1GasLimit = 21000
+    assert(expectedt1GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt1Data: Array[Byte] = Array()
+    assert(expectedt1Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1sigv = Array(0x1B.toByte)
+    assert(expectedt1sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1sigr = Array(0x47.toByte, 0xDD.toByte, 0xF9.toByte, 0x37.toByte, 0x68.toByte, 0x97.toByte, 0x76.toByte, 0x78.toByte, 0x13.toByte, 0x95.toByte, 0x5A.toByte, 0x9D.toByte, 0x46.toByte, 0xB6.toByte, 0xF1.toByte, 0xAA.toByte, 0x77.toByte, 0x73.toByte, 0xE5.toByte, 0xC8.toByte, 0xC6.toByte, 0x21.toByte, 0x67.toByte, 0x54.toByte, 0x1C.toByte, 0x80.toByte, 0xBF.toByte, 0x25.toByte, 0x2D.toByte, 0xC7.toByte, 0xDC.toByte, 0xD2.toByte)
+    assert(expectedt1sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1sigs = Array(0x0A.toByte, 0x31.toByte, 0x3F.toByte, 0x35.toByte, 0x60.toByte, 0x32.toByte, 0x37.toByte, 0x56.toByte, 0xB7.toByte, 0x28.toByte, 0x5F.toByte, 0x62.toByte, 0x38.toByte, 0x51.toByte, 0x86.toByte, 0x05.toByte, 0x82.toByte, 0x1A.toByte, 0x2B.toByte, 0xEE.toByte, 0x03.toByte, 0x7D.toByte, 0xEA.toByte, 0x8F.toByte, 0x09.toByte, 0x22.toByte, 0x66.toByte, 0x20.toByte, 0x89.toByte, 0x03.toByte, 0x74.toByte, 0x59.toByte)
+    assert(expectedt1sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 1
+    val expectedt2Nonce = Array(0xFF.toByte, 0xD7.toByte)
+    assert(expectedt2Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2Value = 5110508700000000000L
+    assert(expectedt2Value == tvalues(transactNum).get(0))
+    val expectedt2ReceiveAddress = Array(0x54.toByte, 0x67.toByte, 0xFA.toByte, 0xBD.toByte, 0x30.toByte, 0xEB.toByte, 0x61.toByte, 0xA1.toByte, 0x84.toByte, 0x61.toByte, 0xD1.toByte, 0x53.toByte, 0xD8.toByte, 0xC6.toByte, 0xFF.toByte, 0xB1.toByte, 0x9D.toByte, 0xD4.toByte, 0x7A.toByte, 0x25.toByte)
+    assert(expectedt2ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2GasPrice = 20000000000L
+    assert(expectedt2GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt2GasLimit = 90000
+    assert(expectedt2GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt2Data: Array[Byte] = Array()
+    assert(expectedt2Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2sigv = Array(0x1B.toByte)
+    assert(expectedt2sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2sigr = Array(0x62.toByte, 0x85.toByte, 0x3C.toByte, 0x63.toByte, 0x9A.toByte, 0x9B.toByte, 0x9E.toByte, 0xC4.toByte, 0x9B.toByte, 0xA9.toByte, 0xAC.toByte, 0x53.toByte, 0xE2.toByte, 0x85.toByte, 0xB3.toByte, 0x4E.toByte, 0xD0.toByte, 0xB7.toByte, 0x65.toByte, 0x5C.toByte, 0x1B.toByte, 0xE3.toByte, 0x29.toByte, 0xFB.toByte, 0x8B.toByte, 0x34.toByte, 0x70.toByte, 0x74.toByte, 0x0C.toByte, 0x3D.toByte, 0x0A.toByte, 0x9A.toByte)
+    assert(expectedt2sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2sigs = Array(0x03.toByte, 0xFA.toByte, 0xA6.toByte, 0xF4.toByte, 0xFF.toByte, 0x1A.toByte, 0x45.toByte, 0x76.toByte, 0xDF.toByte, 0x08.toByte, 0x9A.toByte, 0x9F.toByte, 0x9C.toByte, 0xB7.toByte, 0x9C.toByte, 0xF2.toByte, 0xED.toByte, 0xC1.toByte, 0xC5.toByte, 0xBD.toByte, 0xEC.toByte, 0x0F.toByte, 0xE7.toByte, 0x9C.toByte, 0x79.toByte, 0x2A.toByte, 0xCB.toByte, 0x9E.toByte, 0x83.toByte, 0xF2.toByte, 0x41.toByte)
+    assert(expectedt2sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 2
+    val expectedt3Nonce = Array(0x02.toByte, 0xD7.toByte, 0xDD.toByte)
+    assert(expectedt3Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3Value = 11667800000000000L
+    assert(expectedt3Value == tvalues(transactNum).get(0))
+    val expectedt3ReceiveAddress = Array(0xB4.toByte, 0xD0.toByte, 0xCA.toByte, 0x2B.toByte, 0x7E.toByte, 0x4C.toByte, 0xB1.toByte, 0xE0.toByte, 0x61.toByte, 0x0D.toByte, 0x02.toByte, 0x15.toByte, 0x4A.toByte, 0x10.toByte, 0x16.toByte, 0x3A.toByte, 0xB0.toByte, 0xF4.toByte, 0x2E.toByte, 0x65.toByte)
+    assert(expectedt3ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3GasPrice = 20000000000L
+    assert(expectedt3GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt3GasLimit = 90000
+    assert(expectedt3GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt3Data: Array[Byte] = Array()
+    assert(expectedt3Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3sigv = Array(0x1C.toByte)
+    assert(expectedt3sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3sigr = Array(0x89.toByte, 0xFD.toByte, 0x7A.toByte, 0x62.toByte, 0xCF.toByte, 0x44.toByte, 0x77.toByte, 0xBF.toByte, 0xE5.toByte, 0xDB.toByte, 0xF0.toByte, 0xEE.toByte, 0xCF.toByte, 0x3A.toByte, 0x4A.toByte, 0x96.toByte, 0x71.toByte, 0x96.toByte, 0x96.toByte, 0xFB.toByte, 0xBE.toByte, 0x16.toByte, 0xBA.toByte, 0x0A.toByte, 0xBA.toByte, 0x1D.toByte, 0x63.toByte, 0x1D.toByte, 0x44.toByte, 0xC1.toByte, 0xEB.toByte, 0x58.toByte)
+    assert(expectedt3sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3sigs = Array(0x24.toByte, 0x34.toByte, 0x48.toByte, 0x64.toByte, 0xEB.toByte, 0x6A.toByte, 0x60.toByte, 0xC6.toByte, 0x6F.toByte, 0xB5.toByte, 0xDA.toByte, 0xED.toByte, 0x02.toByte, 0xB5.toByte, 0x63.toByte, 0x52.toByte, 0xE8.toByte, 0x17.toByte, 0x42.toByte, 0x16.toByte, 0xB8.toByte, 0xA2.toByte, 0xD3.toByte, 0x33.toByte, 0xB7.toByte, 0xF3.toByte, 0x32.toByte, 0xFF.toByte, 0x6B.toByte, 0xA0.toByte, 0x69.toByte, 0x9C.toByte)
+    assert(expectedt3sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 3
+    val expectedt4Nonce = Array(0x02.toByte, 0xD7.toByte, 0xDE.toByte)
+    assert(expectedt4Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4Value = 130970170000000000L
+    assert(expectedt4Value == tvalues(transactNum).get(0))
+    val expectedt4ReceiveAddress = Array(0x1F.toByte, 0x57.toByte, 0xF8.toByte, 0x26.toByte, 0xCA.toByte, 0xF5.toByte, 0x94.toByte, 0xF7.toByte, 0xA8.toByte, 0x37.toByte, 0xD9.toByte, 0xFC.toByte, 0x09.toByte, 0x24.toByte, 0x56.toByte, 0x87.toByte, 0x0A.toByte, 0x28.toByte, 0x93.toByte, 0x65.toByte)
+    assert(expectedt4ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4GasPrice = 20000000000L
+    assert(expectedt4GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt4GasLimit = 90000
+    assert(expectedt4GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt4Data: Array[Byte] = Array()
+    assert(expectedt4Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4sigv = Array(0x1B.toByte)
+    assert(expectedt4sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4sigr = Array(0x46.toByte, 0x01.toByte, 0x57.toByte, 0xDC.toByte, 0xE4.toByte, 0xE9.toByte, 0x5D.toByte, 0x1D.toByte, 0xCC.toByte, 0x7A.toByte, 0xED.toByte, 0x0D.toByte, 0x9B.toByte, 0x7E.toByte, 0x3D.toByte, 0x65.toByte, 0x37.toByte, 0x0C.toByte, 0x53.toByte, 0xD2.toByte, 0x9E.toByte, 0xA9.toByte, 0xB1.toByte, 0xAA.toByte, 0x4C.toByte, 0x9C.toByte, 0x22.toByte, 0x14.toByte, 0x91.toByte, 0x1C.toByte, 0xD9.toByte, 0x5E.toByte)
+    assert(expectedt4sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4sigs = Array(0x6A.toByte, 0x84.toByte, 0x4F.toByte, 0x95.toByte, 0x6D.toByte, 0x02.toByte, 0x46.toByte, 0x94.toByte, 0x1B.toByte, 0x94.toByte, 0x30.toByte, 0x91.toByte, 0x34.toByte, 0x21.toByte, 0x20.toByte, 0xBD.toByte, 0x48.toByte, 0xE7.toByte, 0xC6.toByte, 0x35.toByte, 0x77.toByte, 0xF0.toByte, 0xBA.toByte, 0x3D.toByte, 0x87.toByte, 0x59.toByte, 0xC9.toByte, 0xEC.toByte, 0x58.toByte, 0x70.toByte, 0x4E.toByte, 0xEC.toByte)
+    assert(expectedt4sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 4
+    val expectedt5Nonce = Array(0x02.toByte, 0xD7.toByte, 0xDF.toByte)
+    assert(expectedt5Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5Value = 144683800000000000L
+    assert(expectedt5Value == tvalues(transactNum).get(0))
+    val expectedt5ReceiveAddress = Array(0x1F.toByte, 0x57.toByte, 0xF8.toByte, 0x26.toByte, 0xCA.toByte, 0xF5.toByte, 0x94.toByte, 0xF7.toByte, 0xA8.toByte, 0x37.toByte, 0xD9.toByte, 0xFC.toByte, 0x09.toByte, 0x24.toByte, 0x56.toByte, 0x87.toByte, 0x0A.toByte, 0x28.toByte, 0x93.toByte, 0x65.toByte)
+    assert(expectedt5ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5GasPrice = 20000000000L
+    assert(expectedt5GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt5GasLimit = 90000
+    assert(expectedt5GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt5Data: Array[Byte] = Array()
+    assert(expectedt5Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5sigv = Array(0x1C.toByte)
+    assert(expectedt5sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5sigr = Array(0xE4.toByte, 0xBE.toByte, 0x97.toByte, 0xD5.toByte, 0xAF.toByte, 0xF1.toByte, 0xB5.toByte, 0xE7.toByte, 0x99.toByte, 0x12.toByte, 0x96.toByte, 0x98.toByte, 0x2B.toByte, 0xDF.toByte, 0xC1.toByte, 0xC2.toByte, 0x2F.toByte, 0x75.toByte, 0x21.toByte, 0x13.toByte, 0x4F.toByte, 0x7E.toByte, 0x1A.toByte, 0x9D.toByte, 0xA3.toByte, 0x00.toByte, 0x42.toByte, 0x0D.toByte, 0xAD.toByte, 0x33.toByte, 0x6F.toByte, 0x34.toByte)
+    assert(expectedt5sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5sigs = Array(0x62.toByte, 0xDE.toByte, 0xF8.toByte, 0xAA.toByte, 0x83.toByte, 0x65.toByte, 0x58.toByte, 0xC7.toByte, 0xB0.toByte, 0xA5.toByte, 0x65.toByte, 0xB9.toByte, 0x7C.toByte, 0x9B.toByte, 0x27.toByte, 0xB2.toByte, 0x0E.toByte, 0xD9.toByte, 0xA0.toByte, 0x51.toByte, 0xDE.toByte, 0x22.toByte, 0xAD.toByte, 0x8D.toByte, 0xBD.toByte, 0x62.toByte, 0x52.toByte, 0x44.toByte, 0xCE.toByte, 0x64.toByte, 0x9E.toByte, 0x3D.toByte)
+    assert(expectedt5sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 5
+    val expectedt6Nonce = Array(0x02.toByte, 0xD7.toByte, 0xE0.toByte)
+    assert(expectedt6Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6Value = 143694920000000000L
+    assert(expectedt6Value == tvalues(transactNum).get(0))
+    val expectedt6ReceiveAddress = Array(0x1F.toByte, 0x57.toByte, 0xF8.toByte, 0x26.toByte, 0xCA.toByte, 0xF5.toByte, 0x94.toByte, 0xF7.toByte, 0xA8.toByte, 0x37.toByte, 0xD9.toByte, 0xFC.toByte, 0x09.toByte, 0x24.toByte, 0x56.toByte, 0x87.toByte, 0x0A.toByte, 0x28.toByte, 0x93.toByte, 0x65.toByte)
+    assert(expectedt6ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6GasPrice = 20000000000L
+    assert(expectedt6GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt6GasLimit = 90000
+    assert(expectedt6GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt6Data: Array[Byte] = Array()
+    assert(expectedt6Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6sigv = Array(0x1C.toByte)
+    assert(expectedt6sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6sigr = Array(0x0A.toByte, 0x4C.toByte, 0xA2.toByte, 0x18.toByte, 0x46.toByte, 0x0D.toByte, 0xC8.toByte, 0x5B.toByte, 0x99.toByte, 0x07.toByte, 0x46.toByte, 0xFB.toByte, 0xB9.toByte, 0x0C.toByte, 0x06.toByte, 0xF8.toByte, 0x25.toByte, 0x87.toByte, 0x82.toByte, 0x80.toByte, 0x87.toByte, 0x27.toByte, 0x98.toByte, 0x3C.toByte, 0x8B.toByte, 0x8D.toByte, 0x6A.toByte, 0x92.toByte, 0x1E.toByte, 0x19.toByte, 0x9B.toByte, 0xCA.toByte)
+    assert(expectedt6sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6sigs = Array(0x08.toByte, 0xA3.toByte, 0xB9.toByte, 0xA4.toByte, 0x5D.toByte, 0x83.toByte, 0x1A.toByte, 0xC4.toByte, 0xAD.toByte, 0x37.toByte, 0x9D.toByte, 0x14.toByte, 0xF0.toByte, 0xAE.toByte, 0x3C.toByte, 0x03.toByte, 0xC8.toByte, 0x73.toByte, 0x1C.toByte, 0xB4.toByte, 0x4D.toByte, 0x8A.toByte, 0x79.toByte, 0xAC.toByte, 0xD4.toByte, 0xCD.toByte, 0x6C.toByte, 0xEA.toByte, 0x1B.toByte, 0x54.toByte, 0x80.toByte, 0x02.toByte)
+    assert(expectedt6sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
 
-  // uncle headers
+    // uncle headers
     // block does not contain uncleheaders
 
-  import df.sparkSession.implicits._
+    import df.sparkSession.implicits._
 
-  df.as[EthereumBlock].collect()}
+    df.as[EthereumBlock].collect()
+  }
 
   "The block 1346406 on DFS" should "be fully read in dataframe with enriched information" in {
     Given("Block 1346406 on DFSCluster")
@@ -588,9 +584,9 @@ assert(expectedt5ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asIn
     val expectedBhDifficulty = Array(0x19.toByte, 0xFF.toByte, 0x9E.toByte, 0xC4.toByte, 0x35.toByte, 0xE0.toByte)
     val bhDifficulty = df.select("ethereumBlockHeader.difficulty").collect
     assert(expectedBhDifficulty.deep == bhDifficulty(0).get(0).asInstanceOf[Array[Byte]].deep)
-    val format = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z")
-    val expectedDTStr = "16-04-2016 09:34:29 UTC"
-    val expectedBhTimestamp = format.parse(expectedDTStr).getTime / 1000
+    val format = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z");
+    val expectedDTStr = "16-04-2016 09:34:29 UTC";
+    val expectedBhTimestamp = format.parse(expectedDTStr).getTime / 1000;
     val bhTimestamp = df.select("ethereumBlockHeader.timestamp").collect
     assert(expectedBhTimestamp == bhTimestamp(0).get(0))
     val expectedBhNumber = 1346406
@@ -768,12 +764,8 @@ assert(expectedt5ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asIn
     // uncle headers
     // block does not contain uncleheaders
 
+    import df.sparkSession.implicits._
 
-import df.sparkSession.implicits._
-
-  df.as[EnrichedEthereumBlock].collect()
-
-}
-
-
+    df.as[EnrichedEthereumBlock].collect()
+  }
 }

--- a/src/it/scala/org/zuinnote/spark/ethereum/block/SparkEthereumBlockDSSparkMasterIntegrationSpec.scala
+++ b/src/it/scala/org/zuinnote/spark/ethereum/block/SparkEthereumBlockDSSparkMasterIntegrationSpec.scala
@@ -1,138 +1,129 @@
 /**
-* Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+  * Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 
 /**
-*
-* This test integrates HDFS and Spark
-*
-*/
+  *
+  * This test integrates HDFS and Spark
+  *
+  */
 
 package org.zuinnote.spark.ethereum.block
 
 
-import org.apache.hadoop.hdfs.MiniDFSCluster
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.FSDataInputStream
-import org.apache.hadoop.fs.Path
-import java.io.BufferedReader
-import java.io.File
-import java.io.InputStream
-import java.io.InputStreamReader
-import java.io.IOException
-import java.nio.file.attribute.BasicFileAttributes
-import java.nio.file.Files
-import java.nio.file.FileVisitResult
-import java.nio.file.SimpleFileVisitor
-import java.text.SimpleDateFormat
-import java.util.ArrayList
-import java.util.List
 
-import org.apache.hadoop.io.compress.CodecPool
-import org.apache.hadoop.io.compress.CompressionCodec
-import org.apache.hadoop.io.compress.CompressionCodecFactory
-import org.apache.hadoop.io.compress.Decompressor
-import org.apache.hadoop.io.compress.SplittableCompressionCodec
-import org.apache.hadoop.io.compress.SplitCompressionInputStream
-import org.apache.spark.{SparkConf, SparkContext}
+import java.io.{File, IOException}
+import java.nio.file.{FileVisitResult, Files, SimpleFileVisitor}
+import java.nio.file.attribute.BasicFileAttributes
+import java.text.SimpleDateFormat
+
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.hdfs.MiniDFSCluster
+import org.apache.hadoop.io.compress.{CodecPool,Decompressor
+}
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.functions._
 
+import org.apache.spark.{SparkConf, SparkContext}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, GivenWhenThen, Matchers}
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConversions._
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, GivenWhenThen, Matchers}
 import org.zuinnote.spark.ethereum.model.{EnrichedEthereumBlock, EthereumBlock}
 
 class SparkEthereumBlockDSSparkMasterIntegrationSpec extends FlatSpec with BeforeAndAfterAll with GivenWhenThen with Matchers {
 
-private var sc: SparkContext = _
-private var sqlContext: SQLContext = _
-private val master: String = "local[2]"
-private val appName: String = "spark-hadoocryptoledger-ds-integrationtest"
-private val tmpPrefix: String = "hcl-integrationtest"
-private var tmpPath: java.nio.file.Path = _
-private val CLUSTERNAME: String ="hcl-minicluster"
-private val DFS_INPUT_DIR_NAME: String = "/input"
-private val DFS_OUTPUT_DIR_NAME: String = "/output"
-private val DEFAULT_OUTPUT_FILENAME: String = "part-00000"
-private val DFS_INPUT_DIR : Path = new Path(DFS_INPUT_DIR_NAME)
-private val DFS_OUTPUT_DIR : Path = new Path(DFS_OUTPUT_DIR_NAME)
-private val NOOFDATANODES: Int =4
-private var dfsCluster: MiniDFSCluster = _
-private var conf: Configuration = _
-private var openDecompressors = ArrayBuffer[Decompressor]();
+  private var sc: SparkContext = _
+  private var sqlContext: SQLContext = _
+  private val master: String = "local[2]"
+  private val appName: String = "spark-hadoocryptoledger-ds-integrationtest"
+  private val tmpPrefix: String = "hcl-integrationtest"
+  private var tmpPath: java.nio.file.Path = _
+  private val CLUSTERNAME: String = "hcl-minicluster"
+  private val DFS_INPUT_DIR_NAME: String = "/input"
+  private val DFS_OUTPUT_DIR_NAME: String = "/output"
+  private val DEFAULT_OUTPUT_FILENAME: String = "part-00000"
+  private val DFS_INPUT_DIR: Path = new Path(DFS_INPUT_DIR_NAME)
+  private val DFS_OUTPUT_DIR: Path = new Path(DFS_OUTPUT_DIR_NAME)
+  private val NOOFDATANODES: Int = 4
+  private var dfsCluster: MiniDFSCluster = _
+  private var conf: Configuration = _
+  private var openDecompressors = ArrayBuffer[Decompressor]()
 
-override def beforeAll(): Unit = {
+  override def beforeAll(): Unit = {
     super.beforeAll()
 
-		// Create temporary directory for HDFS base and shutdownhook
-	// create temp directory
-      tmpPath = Files.createTempDirectory(tmpPrefix)
-      // create shutdown hook to remove temp files (=HDFS MiniCluster) after shutdown, may need to rethink to avoid many threads are created
-	Runtime.getRuntime.addShutdownHook(new Thread("remove temporary directory") {
-      	 override def run(): Unit =  {
-        	try {
-          		Files.walkFileTree(tmpPath, new SimpleFileVisitor[java.nio.file.Path]() {
+    // Create temporary directory for HDFS base and shutdownhook
+    // create temp directory
+    tmpPath = Files.createTempDirectory(tmpPrefix)
+    // create shutdown hook to remove temp files (=HDFS MiniCluster) after shutdown, may need to rethink to avoid many threads are created
+    Runtime.getRuntime.addShutdownHook(new Thread("remove temporary directory") {
+      override def run(): Unit = {
+        try {
+          Files.walkFileTree(tmpPath, new SimpleFileVisitor[java.nio.file.Path]() {
 
-            		override def visitFile(file: java.nio.file.Path,attrs: BasicFileAttributes): FileVisitResult = {
-                		Files.delete(file)
-             			return FileVisitResult.CONTINUE
-        			}
+            override def visitFile(file: java.nio.file.Path, attrs: BasicFileAttributes): FileVisitResult = {
+              Files.delete(file)
+              FileVisitResult.CONTINUE
+            }
 
-        		override def postVisitDirectory(dir: java.nio.file.Path, e: IOException): FileVisitResult = {
-          			if (e == null) {
-            				Files.delete(dir)
-            				return FileVisitResult.CONTINUE
-          			}
-          			throw e
-        			}
-        	})
-      	} catch {
-        case e: IOException => throw new RuntimeException("Error temporary files in following path could not be deleted "+tmpPath, e)
-    }}})
-	// create DFS mini cluster
-	 conf = new Configuration()
-	val baseDir = new File(tmpPath.toString()).getAbsoluteFile()
-	conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath())
-	val builder = new MiniDFSCluster.Builder(conf)
- 	 dfsCluster = builder.numDataNodes(NOOFDATANODES).build()
-	conf.set("fs.defaultFS", dfsCluster.getFileSystem().getUri().toString())
-	// create local Spark cluster
- 	val sparkConf = new SparkConf()
+            override def postVisitDirectory(dir: java.nio.file.Path, e: IOException): FileVisitResult = {
+              if (e != null) {
+                throw e
+              }
+              Files.delete(dir)
+              FileVisitResult.CONTINUE
+            }
+          })
+        } catch {
+          case e: IOException => throw new RuntimeException("Error temporary files in following path could not be deleted " + tmpPath, e)
+        }
+      }
+    })
+    // create DFS mini cluster
+    conf = new Configuration()
+    val baseDir = new File(tmpPath.toString).getAbsoluteFile
+    conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath)
+    val builder = new MiniDFSCluster.Builder(conf)
+    dfsCluster = builder.numDataNodes(NOOFDATANODES).build()
+    conf.set("fs.defaultFS", dfsCluster.getFileSystem().getUri.toString)
+    // create local Spark cluster
+    val sparkConf = new SparkConf()
       .setMaster("local[2]")
       .setAppName(this.getClass.getSimpleName)
-	sc = new SparkContext(sparkConf)
-	sqlContext = new SQLContext(sc)
- }
-
+    sc = new SparkContext(sparkConf)
+    sqlContext = new SQLContext(sc)
+  }
 
   override def afterAll(): Unit = {
-   // close Spark Context
-    if (sc!=null) {
-	sc.stop()
+    // close Spark Context
+    if (sc != null) {
+      sc.stop()
     }
     // close decompressor
-	for ( currentDecompressor <- this.openDecompressors) {
-		if (currentDecompressor!=null) {
-			 CodecPool.returnDecompressor(currentDecompressor)
-		}
- 	}
+    for (currentDecompressor <- this.openDecompressors) {
+      if (currentDecompressor != null) {
+        CodecPool.returnDecompressor(currentDecompressor)
+      }
+    }
     // close dfs cluster
     dfsCluster.shutdown()
     super.afterAll()
-}
+  }
+
 
 "The block 1346406 on DFS" should "be fully read in dataframe" in {
 	Given("Block 1346406 on DFSCluster")
@@ -140,203 +131,202 @@ override def beforeAll(): Unit = {
    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
 	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
 	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
+	val classLoader = getClass.getClassLoader
     	// put testdata on DFS
     	val fileName: String="eth1346406.bin"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
+    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile
     	val inputFile=new Path(fileNameFullLocal)
     	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
 	When("reading block 1346406 using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.ethereum.block").option("useDirectBuffer", "false").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
+	val df = sqlContext.read.format("org.zuinnote.spark.ethereum.block").option("useDirectBuffer", "false").load(dfsCluster.getFileSystem().getUri.toString+DFS_INPUT_DIR_NAME)
 	Then("all fields should be readable trough Spark SQL")
 	// check first if structure is correct
 	assert("ethereumBlockHeader"==df.columns(0))
 	assert("ethereumTransactions"==df.columns(1))
 	assert("uncleHeaders"==df.columns(2))
 
-  val ethereumTransactionsDF = df.select(explode(df("ethereumTransactions")).alias("ethereumTransactions"))
+    val ethereumTransactionsDF = df.select(explode(df("ethereumTransactions")).alias("ethereumTransactions"))
     val ethereumUncleHeaderDF = df.select(explode(df("uncleHeaders")).alias("uncleHeaders"))
-  // check if content is correct
-  // sanity checks
-  assert(6==ethereumTransactionsDF.count())
-  assert(0==ethereumUncleHeaderDF.count())
-  // check details
-  // block header
-  val expectedBhParentHash = Array(0xba.toByte,0x6d.toByte,0xd2.toByte,0x60.toByte,0x12.toByte,0xb3.toByte,0x71.toByte,0x90.toByte,0x48.toByte,0xf3.toByte,0x16.toByte,0xc6.toByte,0xed.toByte,0xb3.toByte,0x34.toByte,0x9b.toByte,0xdf.toByte,0xbd.toByte,0x61.toByte,0x31.toByte,0x9f.toByte,0xa9.toByte,0x7c.toByte,0x61.toByte,0x6a.toByte,0x61.toByte,0x31.toByte,0x18.toByte,0xa1.toByte,0xaf.toByte,0x30.toByte,0x67.toByte)
-  val bhParentHash = df.select("ethereumBlockHeader.parentHash").collect
-  assert(expectedBhParentHash.deep==bhParentHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectdBhUncleHash = Array(0x1D.toByte,0xCC.toByte,0x4D.toByte,0xE8.toByte,0xDE.toByte,0xC7.toByte,0x5D.toByte,0x7A.toByte,0xAB.toByte,0x85.toByte,0xB5.toByte,0x67.toByte,0xB6.toByte,0xCC.toByte,0xD4.toByte,0x1A.toByte,0xD3.toByte,0x12.toByte,0x45.toByte,0x1B.toByte,0x94.toByte,0x8A.toByte,0x74.toByte,0x13.toByte,0xF0.toByte,0xA1.toByte,0x42.toByte,0xFD.toByte,0x40.toByte,0xD4.toByte,0x93.toByte,0x47.toByte)
-  val bhUncleHash = df.select("ethereumBlockHeader.uncleHash").collect
-  assert(expectdBhUncleHash.deep==bhUncleHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhCoinBase = Array(0x1A.toByte,0x06.toByte,0x0B.toByte,0x06.toByte,0x04.toByte,0x88.toByte,0x3A.toByte,0x99.toByte,0x80.toByte,0x9E.toByte,0xB3.toByte,0xF7.toByte,0x98.toByte,0xDF.toByte,0x71.toByte,0xBE.toByte,0xF6.toByte,0xC3.toByte,0x58.toByte,0xF1.toByte)
-  val bhCoinBase = df.select("ethereumBlockHeader.coinBase").collect
-  assert(expectedBhCoinBase.deep==bhCoinBase(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhStateRoot = Array(0x21.toByte,0xBA.toByte,0x88.toByte,0x6F.toByte,0xD2.toByte,0x6F.toByte,0x17.toByte,0xB4.toByte,0x01.toByte,0xF5.toByte,0x39.toByte,0x20.toByte,0x15.toByte,0x33.toByte,0x10.toByte,0xB6.toByte,0x93.toByte,0x9B.toByte,0xAD.toByte,0x8A.toByte,0x5F.toByte,0xC3.toByte,0xBF.toByte,0x8C.toByte,0x50.toByte,0x5C.toByte,0x55.toByte,0x6D.toByte,0xDB.toByte,0xAF.toByte,0xBC.toByte,0x5C.toByte)
-  val bhStateRoot = df.select("ethereumBlockHeader.stateRoot").collect
-  assert(expectedBhStateRoot.deep==bhStateRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhTxTrieRoot = Array(0xB3.toByte,0xCB.toByte,0xC7.toByte,0xF0.toByte,0xD7.toByte,0x87.toByte,0xE5.toByte,0x7D.toByte,0x93.toByte,0x70.toByte,0xB8.toByte,0x02.toByte,0xAB.toByte,0x94.toByte,0x5E.toByte,0x21.toByte,0x99.toByte,0x1C.toByte,0x3E.toByte,0x12.toByte,0x7D.toByte,0x70.toByte,0x12.toByte,0x0C.toByte,0x37.toByte,0xE9.toByte,0xFD.toByte,0xAE.toByte,0x3E.toByte,0xF3.toByte,0xEB.toByte,0xFC.toByte)
-  val bhTxTrieRoot = df.select("ethereumBlockHeader.txTrieRoot").collect
-  assert(expectedBhTxTrieRoot.deep==bhTxTrieRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhReceiptTrieRoot = Array(0x9B.toByte,0xCE.toByte,0x71.toByte,0x32.toByte,0xF5.toByte,0x2D.toByte,0x4D.toByte,0x45.toByte,0xA8.toByte,0xA2.toByte,0x47.toByte,0x48.toByte,0x47.toByte,0x86.toByte,0xC7.toByte,0x0B.toByte,0xB2.toByte,0xE6.toByte,0x39.toByte,0x59.toByte,0xC8.toByte,0x56.toByte,0x1B.toByte,0x3A.toByte,0xBF.toByte,0xD4.toByte,0xE7.toByte,0x22.toByte,0xE6.toByte,0x00.toByte,0x6A.toByte,0x27.toByte)
-  val bhReceiptTrieRoot = df.select("ethereumBlockHeader.receiptTrieRoot").collect
-  assert(expectedBhReceiptTrieRoot.deep==bhReceiptTrieRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhLogsBloom = Array(0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte)
-  val bhLogsBloom = df.select("ethereumBlockHeader.logsBloom").collect
-  assert(expectedBhLogsBloom.deep==bhLogsBloom(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhDifficulty = Array(0x19.toByte,0xFF.toByte,0x9E.toByte,0xC4.toByte,0x35.toByte,0xE0.toByte)
-  val bhDifficulty = df.select("ethereumBlockHeader.difficulty").collect
-  assert(expectedBhDifficulty.deep==bhDifficulty(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val format = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z");
-	val expectedDTStr = "16-04-2016 09:34:29 UTC";
-  val expectedBhTimestamp = format.parse(expectedDTStr).getTime() / 1000;
-  val bhTimestamp = df.select("ethereumBlockHeader.timestamp").collect
-  assert(expectedBhTimestamp==bhTimestamp(0).get(0))
-  val expectedBhNumber = 1346406
-  val bhNumber = df.select("ethereumBlockHeader.number").collect
-  assert(expectedBhNumber==bhNumber(0).get(0))
-  val expectedBhGasLimit = 4712388
-  val bhGasLimit = df.select("ethereumBlockHeader.gasLimit").collect
-  assert(expectedBhGasLimit==bhGasLimit(0).get(0))
-  val expectedBhGasUsed = 126000
-  val bhGasUsed = df.select("ethereumBlockHeader.gasUsed").collect
-  assert(expectedBhGasUsed==bhGasUsed(0).get(0))
-  val expectedBhMixHash = Array(0x4F.toByte,0x57.toByte,0x71.toByte,0xB7.toByte,0x9A.toByte,0x8E.toByte,0x6E.toByte,0x21.toByte,0x99.toByte,0x35.toByte,0x53.toByte,0x9C.toByte,0x47.toByte,0x3E.toByte,0x23.toByte,0xBA.toByte,0xFD.toByte,0x2C.toByte,0xA3.toByte,0x5C.toByte,0xC1.toByte,0x86.toByte,0x20.toByte,0x66.toByte,0x31.toByte,0xC3.toByte,0xB0.toByte,0x9E.toByte,0xD5.toByte,0x76.toByte,0x19.toByte,0x4A.toByte)
-  val bhMixHash = df.select("ethereumBlockHeader.mixHash").collect
-  assert(expectedBhMixHash.deep==bhMixHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhExtraData = Array(0xD7.toByte,0x83.toByte,0x01.toByte,0x03.toByte,0x05.toByte,0x84.toByte,0x47.toByte,0x65.toByte,0x74.toByte,0x68.toByte,0x87.toByte,0x67.toByte,0x6F.toByte,0x31.toByte,0x2E.toByte,0x35.toByte,0x2E.toByte,0x31.toByte,0x85.toByte,0x6C.toByte,0x69.toByte,0x6E.toByte,0x75.toByte,0x78.toByte)
-  val bhExtraData = df.select("ethereumBlockHeader.extraData").collect
-    assert(expectedBhExtraData.deep==bhExtraData(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhNonce = Array(0xFF.toByte,0x7C.toByte,0x7A.toByte,0xEE.toByte,0x0E.toByte,0x88.toByte,0xC5.toByte,0x2D.toByte)
-  val bhNonce = df.select("ethereumBlockHeader.nonce").collect
-    assert(expectedBhNonce.deep==bhNonce(0).get(0).asInstanceOf[Array[Byte]].deep)
-  // transactions
-  val tnonces = ethereumTransactionsDF.select("ethereumTransactions.nonce").collect
-  val tvalues = ethereumTransactionsDF.select("ethereumTransactions.value").collect
-  val treceiveAddresses = ethereumTransactionsDF.select("ethereumTransactions.receiveAddress").collect
-  val tgasPrices = ethereumTransactionsDF.select("ethereumTransactions.gasPrice").collect
-  val tgasLimits = ethereumTransactionsDF.select("ethereumTransactions.gasLimit").collect
-  val tdatas = ethereumTransactionsDF.select("ethereumTransactions.data").collect
-  val tsigvs = ethereumTransactionsDF.select("ethereumTransactions.sig_v").collect
-  val tsigrs = ethereumTransactionsDF.select("ethereumTransactions.sig_r").collect
-  val tsigss = ethereumTransactionsDF.select("ethereumTransactions.sig_s").collect
-  var transactNum=0
-  val expectedt1Nonce = Array(0x0C.toByte)
-  assert(expectedt1Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1Value = 1069000990000000000L
-  assert(expectedt1Value==tvalues(transactNum).get(0))
-  val expectedt1ReceiveAddress= Array(0x1E.toByte,0x75.toByte,0xF0.toByte,0x2A.toByte,0x6E.toByte,0x9F.toByte,0xF4.toByte,0xFF.toByte,0x16.toByte,0x33.toByte,0x38.toByte,0x25.toByte,0xD9.toByte,0x09.toByte,0xBB.toByte,0x03.toByte,0x33.toByte,0x06.toByte,0xB7.toByte,0x8B.toByte)
-  assert(expectedt1ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1GasPrice=20000000000L
-  assert(expectedt1GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt1GasLimit=21000
-  assert(expectedt1GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt1Data : Array[Byte] = Array()
-  assert(expectedt1Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1sigv = Array(0x1B.toByte)
-  assert(expectedt1sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1sigr = Array(0x47.toByte,0xDD.toByte,0xF9.toByte,0x37.toByte,0x68.toByte,0x97.toByte,0x76.toByte,0x78.toByte,0x13.toByte,0x95.toByte,0x5A.toByte,0x9D.toByte,0x46.toByte,0xB6.toByte,0xF1.toByte,0xAA.toByte,0x77.toByte,0x73.toByte,0xE5.toByte,0xC8.toByte,0xC6.toByte,0x21.toByte,0x67.toByte,0x54.toByte,0x1C.toByte,0x80.toByte,0xBF.toByte,0x25.toByte,0x2D.toByte,0xC7.toByte,0xDC.toByte,0xD2.toByte)
-  assert(expectedt1sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1sigs = Array(0x0A.toByte,0x31.toByte,0x3F.toByte,0x35.toByte,0x60.toByte,0x32.toByte,0x37.toByte,0x56.toByte,0xB7.toByte,0x28.toByte,0x5F.toByte,0x62.toByte,0x38.toByte,0x51.toByte,0x86.toByte,0x05.toByte,0x82.toByte,0x1A.toByte,0x2B.toByte,0xEE.toByte,0x03.toByte,0x7D.toByte,0xEA.toByte,0x8F.toByte,0x09.toByte,0x22.toByte,0x66.toByte,0x20.toByte,0x89.toByte,0x03.toByte,0x74.toByte,0x59.toByte)
-  assert(expectedt1sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  transactNum=1
-  val expectedt2Nonce = Array(0xFF.toByte,0xD7.toByte)
-  assert(expectedt2Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2Value = 5110508700000000000L
-  assert(expectedt2Value==tvalues(transactNum).get(0))
-  val expectedt2ReceiveAddress= Array(0x54.toByte,0x67.toByte,0xFA.toByte,0xBD.toByte,0x30.toByte,0xEB.toByte,0x61.toByte,0xA1.toByte,0x84.toByte,0x61.toByte,0xD1.toByte,0x53.toByte,0xD8.toByte,0xC6.toByte,0xFF.toByte,0xB1.toByte,0x9D.toByte,0xD4.toByte,0x7A.toByte,0x25.toByte)
-  assert(expectedt2ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2GasPrice=20000000000L
-  assert(expectedt2GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt2GasLimit=90000
-  assert(expectedt2GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt2Data : Array[Byte] = Array()
-  assert(expectedt2Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2sigv = Array(0x1B.toByte)
-  assert(expectedt2sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2sigr = Array(0x62.toByte,0x85.toByte,0x3C.toByte,0x63.toByte,0x9A.toByte,0x9B.toByte,0x9E.toByte,0xC4.toByte,0x9B.toByte,0xA9.toByte,0xAC.toByte,0x53.toByte,0xE2.toByte,0x85.toByte,0xB3.toByte,0x4E.toByte,0xD0.toByte,0xB7.toByte,0x65.toByte,0x5C.toByte,0x1B.toByte,0xE3.toByte,0x29.toByte,0xFB.toByte,0x8B.toByte,0x34.toByte,0x70.toByte,0x74.toByte,0x0C.toByte,0x3D.toByte,0x0A.toByte,0x9A.toByte)
-   assert(expectedt2sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2sigs =  Array(0x03.toByte,0xFA.toByte,0xA6.toByte,0xF4.toByte,0xFF.toByte,0x1A.toByte,0x45.toByte,0x76.toByte,0xDF.toByte,0x08.toByte,0x9A.toByte,0x9F.toByte,0x9C.toByte,0xB7.toByte,0x9C.toByte,0xF2.toByte,0xED.toByte,0xC1.toByte,0xC5.toByte,0xBD.toByte,0xEC.toByte,0x0F.toByte,0xE7.toByte,0x9C.toByte,0x79.toByte,0x2A.toByte,0xCB.toByte,0x9E.toByte,0x83.toByte,0xF2.toByte,0x41.toByte)
-  assert(expectedt2sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  transactNum=2
-  val expectedt3Nonce = Array(0x02.toByte,0xD7.toByte,0xDD.toByte)
-  assert(expectedt3Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3Value = 11667800000000000L
-  assert(expectedt3Value==tvalues(transactNum).get(0))
-  val expectedt3ReceiveAddress= Array(0xB4.toByte,0xD0.toByte,0xCA.toByte,0x2B.toByte,0x7E.toByte,0x4C.toByte,0xB1.toByte,0xE0.toByte,0x61.toByte,0x0D.toByte,0x02.toByte,0x15.toByte,0x4A.toByte,0x10.toByte,0x16.toByte,0x3A.toByte,0xB0.toByte,0xF4.toByte,0x2E.toByte,0x65.toByte)
-     assert(expectedt3ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3GasPrice=20000000000L
-  assert(expectedt3GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt3GasLimit=90000
-  assert(expectedt3GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt3Data : Array[Byte] = Array()
-  assert(expectedt3Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3sigv = Array(0x1C.toByte)
-  assert(expectedt3sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3sigr = Array(0x89.toByte,0xFD.toByte,0x7A.toByte,0x62.toByte,0xCF.toByte,0x44.toByte,0x77.toByte,0xBF.toByte,0xE5.toByte,0xDB.toByte,0xF0.toByte,0xEE.toByte,0xCF.toByte,0x3A.toByte,0x4A.toByte,0x96.toByte,0x71.toByte,0x96.toByte,0x96.toByte,0xFB.toByte,0xBE.toByte,0x16.toByte,0xBA.toByte,0x0A.toByte,0xBA.toByte,0x1D.toByte,0x63.toByte,0x1D.toByte,0x44.toByte,0xC1.toByte,0xEB.toByte,0x58.toByte)
-   assert(expectedt3sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3sigs =  Array(0x24.toByte,0x34.toByte,0x48.toByte,0x64.toByte,0xEB.toByte,0x6A.toByte,0x60.toByte,0xC6.toByte,0x6F.toByte,0xB5.toByte,0xDA.toByte,0xED.toByte,0x02.toByte,0xB5.toByte,0x63.toByte,0x52.toByte,0xE8.toByte,0x17.toByte,0x42.toByte,0x16.toByte,0xB8.toByte,0xA2.toByte,0xD3.toByte,0x33.toByte,0xB7.toByte,0xF3.toByte,0x32.toByte,0xFF.toByte,0x6B.toByte,0xA0.toByte,0x69.toByte,0x9C.toByte)
-  assert(expectedt3sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  transactNum=3
-  val expectedt4Nonce = Array(0x02.toByte,0xD7.toByte,0xDE.toByte)
-  assert(expectedt4Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4Value = 130970170000000000L
-  assert(expectedt4Value==tvalues(transactNum).get(0))
-  val expectedt4ReceiveAddress= Array(0x1F.toByte,0x57.toByte,0xF8.toByte,0x26.toByte,0xCA.toByte,0xF5.toByte,0x94.toByte,0xF7.toByte,0xA8.toByte,0x37.toByte,0xD9.toByte,0xFC.toByte,0x09.toByte,0x24.toByte,0x56.toByte,0x87.toByte,0x0A.toByte,0x28.toByte,0x93.toByte,0x65.toByte)
-     assert(expectedt4ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4GasPrice=20000000000L
-  assert(expectedt4GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt4GasLimit=90000
-  assert(expectedt4GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt4Data : Array[Byte] = Array()
-  assert(expectedt4Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4sigv = Array(0x1B.toByte)
-  assert(expectedt4sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4sigr = Array(0x46.toByte,0x01.toByte,0x57.toByte,0xDC.toByte,0xE4.toByte,0xE9.toByte,0x5D.toByte,0x1D.toByte,0xCC.toByte,0x7A.toByte,0xED.toByte,0x0D.toByte,0x9B.toByte,0x7E.toByte,0x3D.toByte,0x65.toByte,0x37.toByte,0x0C.toByte,0x53.toByte,0xD2.toByte,0x9E.toByte,0xA9.toByte,0xB1.toByte,0xAA.toByte,0x4C.toByte,0x9C.toByte,0x22.toByte,0x14.toByte,0x91.toByte,0x1C.toByte,0xD9.toByte,0x5E.toByte)
-    assert(expectedt4sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4sigs = Array(0x6A.toByte,0x84.toByte,0x4F.toByte,0x95.toByte,0x6D.toByte,0x02.toByte,0x46.toByte,0x94.toByte,0x1B.toByte,0x94.toByte,0x30.toByte,0x91.toByte,0x34.toByte,0x21.toByte,0x20.toByte,0xBD.toByte,0x48.toByte,0xE7.toByte,0xC6.toByte,0x35.toByte,0x77.toByte,0xF0.toByte,0xBA.toByte,0x3D.toByte,0x87.toByte,0x59.toByte,0xC9.toByte,0xEC.toByte,0x58.toByte,0x70.toByte,0x4E.toByte,0xEC.toByte)
-    assert(expectedt4sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  transactNum=4
-  val expectedt5Nonce = Array(0x02.toByte,0xD7.toByte,0xDF.toByte)
-  assert(expectedt5Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5Value = 144683800000000000L
-  assert(expectedt5Value==tvalues(transactNum).get(0))
-  val expectedt5ReceiveAddress= Array(0x1F.toByte,0x57.toByte,0xF8.toByte,0x26.toByte,0xCA.toByte,0xF5.toByte,0x94.toByte,0xF7.toByte,0xA8.toByte,0x37.toByte,0xD9.toByte,0xFC.toByte,0x09.toByte,0x24.toByte,0x56.toByte,0x87.toByte,0x0A.toByte,0x28.toByte,0x93.toByte,0x65.toByte)
-assert(expectedt5ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5GasPrice=20000000000L
-  assert(expectedt5GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt5GasLimit=90000
-  assert(expectedt5GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt5Data : Array[Byte] = Array()
-  assert(expectedt5Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5sigv = Array(0x1C.toByte)
-  assert(expectedt5sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5sigr = Array(0xE4.toByte,0xBE.toByte,0x97.toByte,0xD5.toByte,0xAF.toByte,0xF1.toByte,0xB5.toByte,0xE7.toByte,0x99.toByte,0x12.toByte,0x96.toByte,0x98.toByte,0x2B.toByte,0xDF.toByte,0xC1.toByte,0xC2.toByte,0x2F.toByte,0x75.toByte,0x21.toByte,0x13.toByte,0x4F.toByte,0x7E.toByte,0x1A.toByte,0x9D.toByte,0xA3.toByte,0x00.toByte,0x42.toByte,0x0D.toByte,0xAD.toByte,0x33.toByte,0x6F.toByte,0x34.toByte)
-    assert(expectedt5sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5sigs = Array(0x62.toByte,0xDE.toByte,0xF8.toByte,0xAA.toByte,0x83.toByte,0x65.toByte,0x58.toByte,0xC7.toByte,0xB0.toByte,0xA5.toByte,0x65.toByte,0xB9.toByte,0x7C.toByte,0x9B.toByte,0x27.toByte,0xB2.toByte,0x0E.toByte,0xD9.toByte,0xA0.toByte,0x51.toByte,0xDE.toByte,0x22.toByte,0xAD.toByte,0x8D.toByte,0xBD.toByte,0x62.toByte,0x52.toByte,0x44.toByte,0xCE.toByte,0x64.toByte,0x9E.toByte,0x3D.toByte)
-     assert(expectedt5sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  transactNum=5
-  val expectedt6Nonce =  Array(0x02.toByte,0xD7.toByte,0xE0.toByte)
-  assert(expectedt6Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6Value = 143694920000000000L
-  assert(expectedt6Value==tvalues(transactNum).get(0))
-  val expectedt6ReceiveAddress= Array(0x1F.toByte,0x57.toByte,0xF8.toByte,0x26.toByte,0xCA.toByte,0xF5.toByte,0x94.toByte,0xF7.toByte,0xA8.toByte,0x37.toByte,0xD9.toByte,0xFC.toByte,0x09.toByte,0x24.toByte,0x56.toByte,0x87.toByte,0x0A.toByte,0x28.toByte,0x93.toByte,0x65.toByte)
-    assert(expectedt6ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6GasPrice=20000000000L
-  assert(expectedt6GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt6GasLimit=90000
-  assert(expectedt6GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt6Data : Array[Byte] = Array()
-  assert(expectedt6Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6sigv = Array(0x1C.toByte)
-  assert(expectedt6sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6sigr = Array(0x0A.toByte,0x4C.toByte,0xA2.toByte,0x18.toByte,0x46.toByte,0x0D.toByte,0xC8.toByte,0x5B.toByte,0x99.toByte,0x07.toByte,0x46.toByte,0xFB.toByte,0xB9.toByte,0x0C.toByte,0x06.toByte,0xF8.toByte,0x25.toByte,0x87.toByte,0x82.toByte,0x80.toByte,0x87.toByte,0x27.toByte,0x98.toByte,0x3C.toByte,0x8B.toByte,0x8D.toByte,0x6A.toByte,0x92.toByte,0x1E.toByte,0x19.toByte,0x9B.toByte,0xCA.toByte)
-   assert(expectedt6sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6sigs = Array(0x08.toByte,0xA3.toByte,0xB9.toByte,0xA4.toByte,0x5D.toByte,0x83.toByte,0x1A.toByte,0xC4.toByte,0xAD.toByte,0x37.toByte,0x9D.toByte,0x14.toByte,0xF0.toByte,0xAE.toByte,0x3C.toByte,0x03.toByte,0xC8.toByte,0x73.toByte,0x1C.toByte,0xB4.toByte,0x4D.toByte,0x8A.toByte,0x79.toByte,0xAC.toByte,0xD4.toByte,0xCD.toByte,0x6C.toByte,0xEA.toByte,0x1B.toByte,0x54.toByte,0x80.toByte,0x02.toByte)
-  assert(expectedt6sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    // check if content is correct
+    // sanity checks
+    assert(6 == ethereumTransactionsDF.count())
+    assert(0 == ethereumUncleHeaderDF.count())
+    // check details
+    // block header
+    val expectedBhParentHash = Array(0xba.toByte, 0x6d.toByte, 0xd2.toByte, 0x60.toByte, 0x12.toByte, 0xb3.toByte, 0x71.toByte, 0x90.toByte, 0x48.toByte, 0xf3.toByte, 0x16.toByte, 0xc6.toByte, 0xed.toByte, 0xb3.toByte, 0x34.toByte, 0x9b.toByte, 0xdf.toByte, 0xbd.toByte, 0x61.toByte, 0x31.toByte, 0x9f.toByte, 0xa9.toByte, 0x7c.toByte, 0x61.toByte, 0x6a.toByte, 0x61.toByte, 0x31.toByte, 0x18.toByte, 0xa1.toByte, 0xaf.toByte, 0x30.toByte, 0x67.toByte)
+    val bhParentHash = df.select("ethereumBlockHeader.parentHash").collect
+    assert(expectedBhParentHash.deep == bhParentHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectdBhUncleHash = Array(0x1D.toByte, 0xCC.toByte, 0x4D.toByte, 0xE8.toByte, 0xDE.toByte, 0xC7.toByte, 0x5D.toByte, 0x7A.toByte, 0xAB.toByte, 0x85.toByte, 0xB5.toByte, 0x67.toByte, 0xB6.toByte, 0xCC.toByte, 0xD4.toByte, 0x1A.toByte, 0xD3.toByte, 0x12.toByte, 0x45.toByte, 0x1B.toByte, 0x94.toByte, 0x8A.toByte, 0x74.toByte, 0x13.toByte, 0xF0.toByte, 0xA1.toByte, 0x42.toByte, 0xFD.toByte, 0x40.toByte, 0xD4.toByte, 0x93.toByte, 0x47.toByte)
+    val bhUncleHash = df.select("ethereumBlockHeader.uncleHash").collect
+    assert(expectdBhUncleHash.deep == bhUncleHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhCoinBase = Array(0x1A.toByte, 0x06.toByte, 0x0B.toByte, 0x06.toByte, 0x04.toByte, 0x88.toByte, 0x3A.toByte, 0x99.toByte, 0x80.toByte, 0x9E.toByte, 0xB3.toByte, 0xF7.toByte, 0x98.toByte, 0xDF.toByte, 0x71.toByte, 0xBE.toByte, 0xF6.toByte, 0xC3.toByte, 0x58.toByte, 0xF1.toByte)
+    val bhCoinBase = df.select("ethereumBlockHeader.coinBase").collect
+    assert(expectedBhCoinBase.deep == bhCoinBase(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhStateRoot = Array(0x21.toByte, 0xBA.toByte, 0x88.toByte, 0x6F.toByte, 0xD2.toByte, 0x6F.toByte, 0x17.toByte, 0xB4.toByte, 0x01.toByte, 0xF5.toByte, 0x39.toByte, 0x20.toByte, 0x15.toByte, 0x33.toByte, 0x10.toByte, 0xB6.toByte, 0x93.toByte, 0x9B.toByte, 0xAD.toByte, 0x8A.toByte, 0x5F.toByte, 0xC3.toByte, 0xBF.toByte, 0x8C.toByte, 0x50.toByte, 0x5C.toByte, 0x55.toByte, 0x6D.toByte, 0xDB.toByte, 0xAF.toByte, 0xBC.toByte, 0x5C.toByte)
+    val bhStateRoot = df.select("ethereumBlockHeader.stateRoot").collect
+    assert(expectedBhStateRoot.deep == bhStateRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhTxTrieRoot = Array(0xB3.toByte, 0xCB.toByte, 0xC7.toByte, 0xF0.toByte, 0xD7.toByte, 0x87.toByte, 0xE5.toByte, 0x7D.toByte, 0x93.toByte, 0x70.toByte, 0xB8.toByte, 0x02.toByte, 0xAB.toByte, 0x94.toByte, 0x5E.toByte, 0x21.toByte, 0x99.toByte, 0x1C.toByte, 0x3E.toByte, 0x12.toByte, 0x7D.toByte, 0x70.toByte, 0x12.toByte, 0x0C.toByte, 0x37.toByte, 0xE9.toByte, 0xFD.toByte, 0xAE.toByte, 0x3E.toByte, 0xF3.toByte, 0xEB.toByte, 0xFC.toByte)
+    val bhTxTrieRoot = df.select("ethereumBlockHeader.txTrieRoot").collect
+    assert(expectedBhTxTrieRoot.deep == bhTxTrieRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhReceiptTrieRoot = Array(0x9B.toByte, 0xCE.toByte, 0x71.toByte, 0x32.toByte, 0xF5.toByte, 0x2D.toByte, 0x4D.toByte, 0x45.toByte, 0xA8.toByte, 0xA2.toByte, 0x47.toByte, 0x48.toByte, 0x47.toByte, 0x86.toByte, 0xC7.toByte, 0x0B.toByte, 0xB2.toByte, 0xE6.toByte, 0x39.toByte, 0x59.toByte, 0xC8.toByte, 0x56.toByte, 0x1B.toByte, 0x3A.toByte, 0xBF.toByte, 0xD4.toByte, 0xE7.toByte, 0x22.toByte, 0xE6.toByte, 0x00.toByte, 0x6A.toByte, 0x27.toByte)
+    val bhReceiptTrieRoot = df.select("ethereumBlockHeader.receiptTrieRoot").collect
+    assert(expectedBhReceiptTrieRoot.deep == bhReceiptTrieRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhLogsBloom = Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)
+    val bhLogsBloom = df.select("ethereumBlockHeader.logsBloom").collect
+    assert(expectedBhLogsBloom.deep == bhLogsBloom(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhDifficulty = Array(0x19.toByte, 0xFF.toByte, 0x9E.toByte, 0xC4.toByte, 0x35.toByte, 0xE0.toByte)
+    val bhDifficulty = df.select("ethereumBlockHeader.difficulty").collect
+    assert(expectedBhDifficulty.deep == bhDifficulty(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val format = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z")
+    val expectedDTStr = "16-04-2016 09:34:29 UTC"
+    val expectedBhTimestamp = format.parse(expectedDTStr).getTime / 1000
+    val bhTimestamp = df.select("ethereumBlockHeader.timestamp").collect
+    assert(expectedBhTimestamp == bhTimestamp(0).get(0))
+    val expectedBhNumber = 1346406
+    val bhNumber = df.select("ethereumBlockHeader.number").collect
+    assert(expectedBhNumber == bhNumber(0).get(0))
+    val expectedBhGasLimit = 4712388
+    val bhGasLimit = df.select("ethereumBlockHeader.gasLimit").collect
+    assert(expectedBhGasLimit == bhGasLimit(0).get(0))
+    val expectedBhGasUsed = 126000
+    val bhGasUsed = df.select("ethereumBlockHeader.gasUsed").collect
+    assert(expectedBhGasUsed == bhGasUsed(0).get(0))
+    val expectedBhMixHash = Array(0x4F.toByte, 0x57.toByte, 0x71.toByte, 0xB7.toByte, 0x9A.toByte, 0x8E.toByte, 0x6E.toByte, 0x21.toByte, 0x99.toByte, 0x35.toByte, 0x53.toByte, 0x9C.toByte, 0x47.toByte, 0x3E.toByte, 0x23.toByte, 0xBA.toByte, 0xFD.toByte, 0x2C.toByte, 0xA3.toByte, 0x5C.toByte, 0xC1.toByte, 0x86.toByte, 0x20.toByte, 0x66.toByte, 0x31.toByte, 0xC3.toByte, 0xB0.toByte, 0x9E.toByte, 0xD5.toByte, 0x76.toByte, 0x19.toByte, 0x4A.toByte)
+    val bhMixHash = df.select("ethereumBlockHeader.mixHash").collect
+    assert(expectedBhMixHash.deep == bhMixHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhExtraData = Array(0xD7.toByte, 0x83.toByte, 0x01.toByte, 0x03.toByte, 0x05.toByte, 0x84.toByte, 0x47.toByte, 0x65.toByte, 0x74.toByte, 0x68.toByte, 0x87.toByte, 0x67.toByte, 0x6F.toByte, 0x31.toByte, 0x2E.toByte, 0x35.toByte, 0x2E.toByte, 0x31.toByte, 0x85.toByte, 0x6C.toByte, 0x69.toByte, 0x6E.toByte, 0x75.toByte, 0x78.toByte)
+    val bhExtraData = df.select("ethereumBlockHeader.extraData").collect
+    assert(expectedBhExtraData.deep == bhExtraData(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhNonce = Array(0xFF.toByte, 0x7C.toByte, 0x7A.toByte, 0xEE.toByte, 0x0E.toByte, 0x88.toByte, 0xC5.toByte, 0x2D.toByte)
+    val bhNonce = df.select("ethereumBlockHeader.nonce").collect
+    assert(expectedBhNonce.deep == bhNonce(0).get(0).asInstanceOf[Array[Byte]].deep)
+    // transactions
+    val tnonces = ethereumTransactionsDF.select("ethereumTransactions.nonce").collect
+    val tvalues = ethereumTransactionsDF.select("ethereumTransactions.value").collect
+    val treceiveAddresses = ethereumTransactionsDF.select("ethereumTransactions.receiveAddress").collect
+    val tgasPrices = ethereumTransactionsDF.select("ethereumTransactions.gasPrice").collect
+    val tgasLimits = ethereumTransactionsDF.select("ethereumTransactions.gasLimit").collect
+    val tdatas = ethereumTransactionsDF.select("ethereumTransactions.data").collect
+    val tsigvs = ethereumTransactionsDF.select("ethereumTransactions.sig_v").collect
+    val tsigrs = ethereumTransactionsDF.select("ethereumTransactions.sig_r").collect
+    val tsigss = ethereumTransactionsDF.select("ethereumTransactions.sig_s").collect
+    var transactNum = 0
+    val expectedt1Nonce = Array(0x0C.toByte)
+    assert(expectedt1Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1Value = 1069000990000000000L
+    assert(expectedt1Value == tvalues(transactNum).get(0))
+    val expectedt1ReceiveAddress = Array(0x1E.toByte, 0x75.toByte, 0xF0.toByte, 0x2A.toByte, 0x6E.toByte, 0x9F.toByte, 0xF4.toByte, 0xFF.toByte, 0x16.toByte, 0x33.toByte, 0x38.toByte, 0x25.toByte, 0xD9.toByte, 0x09.toByte, 0xBB.toByte, 0x03.toByte, 0x33.toByte, 0x06.toByte, 0xB7.toByte, 0x8B.toByte)
+    assert(expectedt1ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1GasPrice = 20000000000L
+    assert(expectedt1GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt1GasLimit = 21000
+    assert(expectedt1GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt1Data: Array[Byte] = Array()
+    assert(expectedt1Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1sigv = Array(0x1B.toByte)
+    assert(expectedt1sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1sigr = Array(0x47.toByte, 0xDD.toByte, 0xF9.toByte, 0x37.toByte, 0x68.toByte, 0x97.toByte, 0x76.toByte, 0x78.toByte, 0x13.toByte, 0x95.toByte, 0x5A.toByte, 0x9D.toByte, 0x46.toByte, 0xB6.toByte, 0xF1.toByte, 0xAA.toByte, 0x77.toByte, 0x73.toByte, 0xE5.toByte, 0xC8.toByte, 0xC6.toByte, 0x21.toByte, 0x67.toByte, 0x54.toByte, 0x1C.toByte, 0x80.toByte, 0xBF.toByte, 0x25.toByte, 0x2D.toByte, 0xC7.toByte, 0xDC.toByte, 0xD2.toByte)
+    assert(expectedt1sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1sigs = Array(0x0A.toByte, 0x31.toByte, 0x3F.toByte, 0x35.toByte, 0x60.toByte, 0x32.toByte, 0x37.toByte, 0x56.toByte, 0xB7.toByte, 0x28.toByte, 0x5F.toByte, 0x62.toByte, 0x38.toByte, 0x51.toByte, 0x86.toByte, 0x05.toByte, 0x82.toByte, 0x1A.toByte, 0x2B.toByte, 0xEE.toByte, 0x03.toByte, 0x7D.toByte, 0xEA.toByte, 0x8F.toByte, 0x09.toByte, 0x22.toByte, 0x66.toByte, 0x20.toByte, 0x89.toByte, 0x03.toByte, 0x74.toByte, 0x59.toByte)
+    assert(expectedt1sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 1
+    val expectedt2Nonce = Array(0xFF.toByte, 0xD7.toByte)
+    assert(expectedt2Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2Value = 5110508700000000000L
+    assert(expectedt2Value == tvalues(transactNum).get(0))
+    val expectedt2ReceiveAddress = Array(0x54.toByte, 0x67.toByte, 0xFA.toByte, 0xBD.toByte, 0x30.toByte, 0xEB.toByte, 0x61.toByte, 0xA1.toByte, 0x84.toByte, 0x61.toByte, 0xD1.toByte, 0x53.toByte, 0xD8.toByte, 0xC6.toByte, 0xFF.toByte, 0xB1.toByte, 0x9D.toByte, 0xD4.toByte, 0x7A.toByte, 0x25.toByte)
+    assert(expectedt2ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2GasPrice = 20000000000L
+    assert(expectedt2GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt2GasLimit = 90000
+    assert(expectedt2GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt2Data: Array[Byte] = Array()
+    assert(expectedt2Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2sigv = Array(0x1B.toByte)
+    assert(expectedt2sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2sigr = Array(0x62.toByte, 0x85.toByte, 0x3C.toByte, 0x63.toByte, 0x9A.toByte, 0x9B.toByte, 0x9E.toByte, 0xC4.toByte, 0x9B.toByte, 0xA9.toByte, 0xAC.toByte, 0x53.toByte, 0xE2.toByte, 0x85.toByte, 0xB3.toByte, 0x4E.toByte, 0xD0.toByte, 0xB7.toByte, 0x65.toByte, 0x5C.toByte, 0x1B.toByte, 0xE3.toByte, 0x29.toByte, 0xFB.toByte, 0x8B.toByte, 0x34.toByte, 0x70.toByte, 0x74.toByte, 0x0C.toByte, 0x3D.toByte, 0x0A.toByte, 0x9A.toByte)
+    assert(expectedt2sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2sigs = Array(0x03.toByte, 0xFA.toByte, 0xA6.toByte, 0xF4.toByte, 0xFF.toByte, 0x1A.toByte, 0x45.toByte, 0x76.toByte, 0xDF.toByte, 0x08.toByte, 0x9A.toByte, 0x9F.toByte, 0x9C.toByte, 0xB7.toByte, 0x9C.toByte, 0xF2.toByte, 0xED.toByte, 0xC1.toByte, 0xC5.toByte, 0xBD.toByte, 0xEC.toByte, 0x0F.toByte, 0xE7.toByte, 0x9C.toByte, 0x79.toByte, 0x2A.toByte, 0xCB.toByte, 0x9E.toByte, 0x83.toByte, 0xF2.toByte, 0x41.toByte)
+    assert(expectedt2sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 2
+    val expectedt3Nonce = Array(0x02.toByte, 0xD7.toByte, 0xDD.toByte)
+    assert(expectedt3Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3Value = 11667800000000000L
+    assert(expectedt3Value == tvalues(transactNum).get(0))
+    val expectedt3ReceiveAddress = Array(0xB4.toByte, 0xD0.toByte, 0xCA.toByte, 0x2B.toByte, 0x7E.toByte, 0x4C.toByte, 0xB1.toByte, 0xE0.toByte, 0x61.toByte, 0x0D.toByte, 0x02.toByte, 0x15.toByte, 0x4A.toByte, 0x10.toByte, 0x16.toByte, 0x3A.toByte, 0xB0.toByte, 0xF4.toByte, 0x2E.toByte, 0x65.toByte)
+    assert(expectedt3ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3GasPrice = 20000000000L
+    assert(expectedt3GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt3GasLimit = 90000
+    assert(expectedt3GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt3Data: Array[Byte] = Array()
+    assert(expectedt3Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3sigv = Array(0x1C.toByte)
+    assert(expectedt3sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3sigr = Array(0x89.toByte, 0xFD.toByte, 0x7A.toByte, 0x62.toByte, 0xCF.toByte, 0x44.toByte, 0x77.toByte, 0xBF.toByte, 0xE5.toByte, 0xDB.toByte, 0xF0.toByte, 0xEE.toByte, 0xCF.toByte, 0x3A.toByte, 0x4A.toByte, 0x96.toByte, 0x71.toByte, 0x96.toByte, 0x96.toByte, 0xFB.toByte, 0xBE.toByte, 0x16.toByte, 0xBA.toByte, 0x0A.toByte, 0xBA.toByte, 0x1D.toByte, 0x63.toByte, 0x1D.toByte, 0x44.toByte, 0xC1.toByte, 0xEB.toByte, 0x58.toByte)
+    assert(expectedt3sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3sigs = Array(0x24.toByte, 0x34.toByte, 0x48.toByte, 0x64.toByte, 0xEB.toByte, 0x6A.toByte, 0x60.toByte, 0xC6.toByte, 0x6F.toByte, 0xB5.toByte, 0xDA.toByte, 0xED.toByte, 0x02.toByte, 0xB5.toByte, 0x63.toByte, 0x52.toByte, 0xE8.toByte, 0x17.toByte, 0x42.toByte, 0x16.toByte, 0xB8.toByte, 0xA2.toByte, 0xD3.toByte, 0x33.toByte, 0xB7.toByte, 0xF3.toByte, 0x32.toByte, 0xFF.toByte, 0x6B.toByte, 0xA0.toByte, 0x69.toByte, 0x9C.toByte)
+    assert(expectedt3sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 3
+    val expectedt4Nonce = Array(0x02.toByte, 0xD7.toByte, 0xDE.toByte)
+    assert(expectedt4Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4Value = 130970170000000000L
+    assert(expectedt4Value == tvalues(transactNum).get(0))
+    val expectedt4ReceiveAddress = Array(0x1F.toByte, 0x57.toByte, 0xF8.toByte, 0x26.toByte, 0xCA.toByte, 0xF5.toByte, 0x94.toByte, 0xF7.toByte, 0xA8.toByte, 0x37.toByte, 0xD9.toByte, 0xFC.toByte, 0x09.toByte, 0x24.toByte, 0x56.toByte, 0x87.toByte, 0x0A.toByte, 0x28.toByte, 0x93.toByte, 0x65.toByte)
+    assert(expectedt4ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4GasPrice = 20000000000L
+    assert(expectedt4GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt4GasLimit = 90000
+    assert(expectedt4GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt4Data: Array[Byte] = Array()
+    assert(expectedt4Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4sigv = Array(0x1B.toByte)
+    assert(expectedt4sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4sigr = Array(0x46.toByte, 0x01.toByte, 0x57.toByte, 0xDC.toByte, 0xE4.toByte, 0xE9.toByte, 0x5D.toByte, 0x1D.toByte, 0xCC.toByte, 0x7A.toByte, 0xED.toByte, 0x0D.toByte, 0x9B.toByte, 0x7E.toByte, 0x3D.toByte, 0x65.toByte, 0x37.toByte, 0x0C.toByte, 0x53.toByte, 0xD2.toByte, 0x9E.toByte, 0xA9.toByte, 0xB1.toByte, 0xAA.toByte, 0x4C.toByte, 0x9C.toByte, 0x22.toByte, 0x14.toByte, 0x91.toByte, 0x1C.toByte, 0xD9.toByte, 0x5E.toByte)
+    assert(expectedt4sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4sigs = Array(0x6A.toByte, 0x84.toByte, 0x4F.toByte, 0x95.toByte, 0x6D.toByte, 0x02.toByte, 0x46.toByte, 0x94.toByte, 0x1B.toByte, 0x94.toByte, 0x30.toByte, 0x91.toByte, 0x34.toByte, 0x21.toByte, 0x20.toByte, 0xBD.toByte, 0x48.toByte, 0xE7.toByte, 0xC6.toByte, 0x35.toByte, 0x77.toByte, 0xF0.toByte, 0xBA.toByte, 0x3D.toByte, 0x87.toByte, 0x59.toByte, 0xC9.toByte, 0xEC.toByte, 0x58.toByte, 0x70.toByte, 0x4E.toByte, 0xEC.toByte)
+    assert(expectedt4sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 4
+    val expectedt5Nonce = Array(0x02.toByte, 0xD7.toByte, 0xDF.toByte)
+    assert(expectedt5Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5Value = 144683800000000000L
+    assert(expectedt5Value == tvalues(transactNum).get(0))
+    val expectedt5ReceiveAddress = Array(0x1F.toByte, 0x57.toByte, 0xF8.toByte, 0x26.toByte, 0xCA.toByte, 0xF5.toByte, 0x94.toByte, 0xF7.toByte, 0xA8.toByte, 0x37.toByte, 0xD9.toByte, 0xFC.toByte, 0x09.toByte, 0x24.toByte, 0x56.toByte, 0x87.toByte, 0x0A.toByte, 0x28.toByte, 0x93.toByte, 0x65.toByte)
+    assert(expectedt5ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5GasPrice = 20000000000L
+    assert(expectedt5GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt5GasLimit = 90000
+    assert(expectedt5GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt5Data: Array[Byte] = Array()
+    assert(expectedt5Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5sigv = Array(0x1C.toByte)
+    assert(expectedt5sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5sigr = Array(0xE4.toByte, 0xBE.toByte, 0x97.toByte, 0xD5.toByte, 0xAF.toByte, 0xF1.toByte, 0xB5.toByte, 0xE7.toByte, 0x99.toByte, 0x12.toByte, 0x96.toByte, 0x98.toByte, 0x2B.toByte, 0xDF.toByte, 0xC1.toByte, 0xC2.toByte, 0x2F.toByte, 0x75.toByte, 0x21.toByte, 0x13.toByte, 0x4F.toByte, 0x7E.toByte, 0x1A.toByte, 0x9D.toByte, 0xA3.toByte, 0x00.toByte, 0x42.toByte, 0x0D.toByte, 0xAD.toByte, 0x33.toByte, 0x6F.toByte, 0x34.toByte)
+    assert(expectedt5sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5sigs = Array(0x62.toByte, 0xDE.toByte, 0xF8.toByte, 0xAA.toByte, 0x83.toByte, 0x65.toByte, 0x58.toByte, 0xC7.toByte, 0xB0.toByte, 0xA5.toByte, 0x65.toByte, 0xB9.toByte, 0x7C.toByte, 0x9B.toByte, 0x27.toByte, 0xB2.toByte, 0x0E.toByte, 0xD9.toByte, 0xA0.toByte, 0x51.toByte, 0xDE.toByte, 0x22.toByte, 0xAD.toByte, 0x8D.toByte, 0xBD.toByte, 0x62.toByte, 0x52.toByte, 0x44.toByte, 0xCE.toByte, 0x64.toByte, 0x9E.toByte, 0x3D.toByte)
+    assert(expectedt5sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 5
+    val expectedt6Nonce = Array(0x02.toByte, 0xD7.toByte, 0xE0.toByte)
+    assert(expectedt6Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6Value = 143694920000000000L
+    assert(expectedt6Value == tvalues(transactNum).get(0))
+    val expectedt6ReceiveAddress = Array(0x1F.toByte, 0x57.toByte, 0xF8.toByte, 0x26.toByte, 0xCA.toByte, 0xF5.toByte, 0x94.toByte, 0xF7.toByte, 0xA8.toByte, 0x37.toByte, 0xD9.toByte, 0xFC.toByte, 0x09.toByte, 0x24.toByte, 0x56.toByte, 0x87.toByte, 0x0A.toByte, 0x28.toByte, 0x93.toByte, 0x65.toByte)
+    assert(expectedt6ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6GasPrice = 20000000000L
+    assert(expectedt6GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt6GasLimit = 90000
+    assert(expectedt6GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt6Data: Array[Byte] = Array()
+    assert(expectedt6Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6sigv = Array(0x1C.toByte)
+    assert(expectedt6sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6sigr = Array(0x0A.toByte, 0x4C.toByte, 0xA2.toByte, 0x18.toByte, 0x46.toByte, 0x0D.toByte, 0xC8.toByte, 0x5B.toByte, 0x99.toByte, 0x07.toByte, 0x46.toByte, 0xFB.toByte, 0xB9.toByte, 0x0C.toByte, 0x06.toByte, 0xF8.toByte, 0x25.toByte, 0x87.toByte, 0x82.toByte, 0x80.toByte, 0x87.toByte, 0x27.toByte, 0x98.toByte, 0x3C.toByte, 0x8B.toByte, 0x8D.toByte, 0x6A.toByte, 0x92.toByte, 0x1E.toByte, 0x19.toByte, 0x9B.toByte, 0xCA.toByte)
+    assert(expectedt6sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6sigs = Array(0x08.toByte, 0xA3.toByte, 0xB9.toByte, 0xA4.toByte, 0x5D.toByte, 0x83.toByte, 0x1A.toByte, 0xC4.toByte, 0xAD.toByte, 0x37.toByte, 0x9D.toByte, 0x14.toByte, 0xF0.toByte, 0xAE.toByte, 0x3C.toByte, 0x03.toByte, 0xC8.toByte, 0x73.toByte, 0x1C.toByte, 0xB4.toByte, 0x4D.toByte, 0x8A.toByte, 0x79.toByte, 0xAC.toByte, 0xD4.toByte, 0xCD.toByte, 0x6C.toByte, 0xEA.toByte, 0x1B.toByte, 0x54.toByte, 0x80.toByte, 0x02.toByte)
+    assert(expectedt6sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
 
-  // uncle headers
+    // uncle headers
     // block does not contain uncleheaders
-
 }
 
 "The block 1346406 on DFS" should "be fully read in dataframe (with rich data types)" in {
@@ -544,248 +534,246 @@ assert(expectedt5ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asIn
 
   import df.sparkSession.implicits._
 
-  df.as[EthereumBlock].collect()
-}
+  df.as[EthereumBlock].collect()}
 
+  "The block 1346406 on DFS" should "be fully read in dataframe with enriched information" in {
+    Given("Block 1346406 on DFSCluster")
+    // create input directory
+    dfsCluster.getFileSystem().delete(DFS_INPUT_DIR, true)
+    dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
+    // copy bitcoin blocks
+    val classLoader = getClass.getClassLoader
+    // put testdata on DFS
+    val fileName: String = "eth1346406.bin"
+    val fileNameFullLocal = classLoader.getResource("testdata/" + fileName).getFile
+    val inputFile = new Path(fileNameFullLocal)
+    dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
+    When("reading block 1346406 using datasource")
+    val df = sqlContext.read.format("org.zuinnote.spark.ethereum.block").option("enrich", "true").load(dfsCluster.getFileSystem().getUri.toString + DFS_INPUT_DIR_NAME)
+    Then("all fields should be readable trough Spark SQL")
+    // check first if structure is correct
+    assert("ethereumBlockHeader" == df.columns(0))
+    assert("ethereumTransactions" == df.columns(1))
+    assert("uncleHeaders" == df.columns(2))
 
-"The block 1346406 on DFS" should "be fully read in dataframe with enriched information" in {
-	Given("Block 1346406 on DFSCluster")
-	// create input directory
-   dfsCluster.getFileSystem().delete(DFS_INPUT_DIR,true)
-	dfsCluster.getFileSystem().mkdirs(DFS_INPUT_DIR)
-	// copy bitcoin blocks
-	val classLoader = getClass().getClassLoader()
-    	// put testdata on DFS
-    	val fileName: String="eth1346406.bin"
-    	val fileNameFullLocal=classLoader.getResource("testdata/"+fileName).getFile()
-    	val inputFile=new Path(fileNameFullLocal)
-    	dfsCluster.getFileSystem().copyFromLocalFile(false, false, inputFile, DFS_INPUT_DIR)
-	When("reading block 1346406 using datasource")
-	val df = sqlContext.read.format("org.zuinnote.spark.ethereum.block").option("enrich", "true").load(dfsCluster.getFileSystem().getUri().toString()+DFS_INPUT_DIR_NAME)
-	Then("all fields should be readable trough Spark SQL")
-  // check first if structure is correct
-  assert("ethereumBlockHeader"==df.columns(0))
-  assert("ethereumTransactions"==df.columns(1))
-  assert("uncleHeaders"==df.columns(2))
-
-  val ethereumTransactionsDF = df.select(explode(df("ethereumTransactions")).alias("ethereumTransactions"))
+    val ethereumTransactionsDF = df.select(explode(df("ethereumTransactions")).alias("ethereumTransactions"))
     val ethereumUncleHeaderDF = df.select(explode(df("uncleHeaders")).alias("uncleHeaders"))
-  // check if content is correct
-  // sanity checks
-  assert(6==ethereumTransactionsDF.count())
-  assert(0==ethereumUncleHeaderDF.count())
-  // check details
-  // block header
-  val expectedBhParentHash = Array(0xba.toByte,0x6d.toByte,0xd2.toByte,0x60.toByte,0x12.toByte,0xb3.toByte,0x71.toByte,0x90.toByte,0x48.toByte,0xf3.toByte,0x16.toByte,0xc6.toByte,0xed.toByte,0xb3.toByte,0x34.toByte,0x9b.toByte,0xdf.toByte,0xbd.toByte,0x61.toByte,0x31.toByte,0x9f.toByte,0xa9.toByte,0x7c.toByte,0x61.toByte,0x6a.toByte,0x61.toByte,0x31.toByte,0x18.toByte,0xa1.toByte,0xaf.toByte,0x30.toByte,0x67.toByte)
-  val bhParentHash = df.select("ethereumBlockHeader.parentHash").collect
-  assert(expectedBhParentHash.deep==bhParentHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectdBhUncleHash = Array(0x1D.toByte,0xCC.toByte,0x4D.toByte,0xE8.toByte,0xDE.toByte,0xC7.toByte,0x5D.toByte,0x7A.toByte,0xAB.toByte,0x85.toByte,0xB5.toByte,0x67.toByte,0xB6.toByte,0xCC.toByte,0xD4.toByte,0x1A.toByte,0xD3.toByte,0x12.toByte,0x45.toByte,0x1B.toByte,0x94.toByte,0x8A.toByte,0x74.toByte,0x13.toByte,0xF0.toByte,0xA1.toByte,0x42.toByte,0xFD.toByte,0x40.toByte,0xD4.toByte,0x93.toByte,0x47.toByte)
-  val bhUncleHash = df.select("ethereumBlockHeader.uncleHash").collect
-  assert(expectdBhUncleHash.deep==bhUncleHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhCoinBase = Array(0x1A.toByte,0x06.toByte,0x0B.toByte,0x06.toByte,0x04.toByte,0x88.toByte,0x3A.toByte,0x99.toByte,0x80.toByte,0x9E.toByte,0xB3.toByte,0xF7.toByte,0x98.toByte,0xDF.toByte,0x71.toByte,0xBE.toByte,0xF6.toByte,0xC3.toByte,0x58.toByte,0xF1.toByte)
-  val bhCoinBase = df.select("ethereumBlockHeader.coinBase").collect
-  assert(expectedBhCoinBase.deep==bhCoinBase(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhStateRoot = Array(0x21.toByte,0xBA.toByte,0x88.toByte,0x6F.toByte,0xD2.toByte,0x6F.toByte,0x17.toByte,0xB4.toByte,0x01.toByte,0xF5.toByte,0x39.toByte,0x20.toByte,0x15.toByte,0x33.toByte,0x10.toByte,0xB6.toByte,0x93.toByte,0x9B.toByte,0xAD.toByte,0x8A.toByte,0x5F.toByte,0xC3.toByte,0xBF.toByte,0x8C.toByte,0x50.toByte,0x5C.toByte,0x55.toByte,0x6D.toByte,0xDB.toByte,0xAF.toByte,0xBC.toByte,0x5C.toByte)
-  val bhStateRoot = df.select("ethereumBlockHeader.stateRoot").collect
-  assert(expectedBhStateRoot.deep==bhStateRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhTxTrieRoot = Array(0xB3.toByte,0xCB.toByte,0xC7.toByte,0xF0.toByte,0xD7.toByte,0x87.toByte,0xE5.toByte,0x7D.toByte,0x93.toByte,0x70.toByte,0xB8.toByte,0x02.toByte,0xAB.toByte,0x94.toByte,0x5E.toByte,0x21.toByte,0x99.toByte,0x1C.toByte,0x3E.toByte,0x12.toByte,0x7D.toByte,0x70.toByte,0x12.toByte,0x0C.toByte,0x37.toByte,0xE9.toByte,0xFD.toByte,0xAE.toByte,0x3E.toByte,0xF3.toByte,0xEB.toByte,0xFC.toByte)
-  val bhTxTrieRoot = df.select("ethereumBlockHeader.txTrieRoot").collect
-  assert(expectedBhTxTrieRoot.deep==bhTxTrieRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhReceiptTrieRoot = Array(0x9B.toByte,0xCE.toByte,0x71.toByte,0x32.toByte,0xF5.toByte,0x2D.toByte,0x4D.toByte,0x45.toByte,0xA8.toByte,0xA2.toByte,0x47.toByte,0x48.toByte,0x47.toByte,0x86.toByte,0xC7.toByte,0x0B.toByte,0xB2.toByte,0xE6.toByte,0x39.toByte,0x59.toByte,0xC8.toByte,0x56.toByte,0x1B.toByte,0x3A.toByte,0xBF.toByte,0xD4.toByte,0xE7.toByte,0x22.toByte,0xE6.toByte,0x00.toByte,0x6A.toByte,0x27.toByte)
-  val bhReceiptTrieRoot = df.select("ethereumBlockHeader.receiptTrieRoot").collect
-  assert(expectedBhReceiptTrieRoot.deep==bhReceiptTrieRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhLogsBloom = Array(0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte,0x00.toByte)
-  val bhLogsBloom = df.select("ethereumBlockHeader.logsBloom").collect
-  assert(expectedBhLogsBloom.deep==bhLogsBloom(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhDifficulty = Array(0x19.toByte,0xFF.toByte,0x9E.toByte,0xC4.toByte,0x35.toByte,0xE0.toByte)
-  val bhDifficulty = df.select("ethereumBlockHeader.difficulty").collect
-  assert(expectedBhDifficulty.deep==bhDifficulty(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val format = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z");
-  val expectedDTStr = "16-04-2016 09:34:29 UTC";
-  val expectedBhTimestamp = format.parse(expectedDTStr).getTime() / 1000;
-  val bhTimestamp = df.select("ethereumBlockHeader.timestamp").collect
-  assert(expectedBhTimestamp==bhTimestamp(0).get(0))
-  val expectedBhNumber = 1346406
-  val bhNumber = df.select("ethereumBlockHeader.number").collect
-  assert(expectedBhNumber==bhNumber(0).get(0))
-  val expectedBhGasLimit = 4712388
-  val bhGasLimit = df.select("ethereumBlockHeader.gasLimit").collect
-  assert(expectedBhGasLimit==bhGasLimit(0).get(0))
-  val expectedBhGasUsed = 126000
-  val bhGasUsed = df.select("ethereumBlockHeader.gasUsed").collect
-  assert(expectedBhGasUsed==bhGasUsed(0).get(0))
-  val expectedBhMixHash = Array(0x4F.toByte,0x57.toByte,0x71.toByte,0xB7.toByte,0x9A.toByte,0x8E.toByte,0x6E.toByte,0x21.toByte,0x99.toByte,0x35.toByte,0x53.toByte,0x9C.toByte,0x47.toByte,0x3E.toByte,0x23.toByte,0xBA.toByte,0xFD.toByte,0x2C.toByte,0xA3.toByte,0x5C.toByte,0xC1.toByte,0x86.toByte,0x20.toByte,0x66.toByte,0x31.toByte,0xC3.toByte,0xB0.toByte,0x9E.toByte,0xD5.toByte,0x76.toByte,0x19.toByte,0x4A.toByte)
-  val bhMixHash = df.select("ethereumBlockHeader.mixHash").collect
-  assert(expectedBhMixHash.deep==bhMixHash(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhExtraData = Array(0xD7.toByte,0x83.toByte,0x01.toByte,0x03.toByte,0x05.toByte,0x84.toByte,0x47.toByte,0x65.toByte,0x74.toByte,0x68.toByte,0x87.toByte,0x67.toByte,0x6F.toByte,0x31.toByte,0x2E.toByte,0x35.toByte,0x2E.toByte,0x31.toByte,0x85.toByte,0x6C.toByte,0x69.toByte,0x6E.toByte,0x75.toByte,0x78.toByte)
-  val bhExtraData = df.select("ethereumBlockHeader.extraData").collect
-    assert(expectedBhExtraData.deep==bhExtraData(0).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedBhNonce = Array(0xFF.toByte,0x7C.toByte,0x7A.toByte,0xEE.toByte,0x0E.toByte,0x88.toByte,0xC5.toByte,0x2D.toByte)
-  val bhNonce = df.select("ethereumBlockHeader.nonce").collect
-    assert(expectedBhNonce.deep==bhNonce(0).get(0).asInstanceOf[Array[Byte]].deep)
-  // transactions
-  val tnonces = ethereumTransactionsDF.select("ethereumTransactions.nonce").collect
-  val tvalues = ethereumTransactionsDF.select("ethereumTransactions.value").collect
-  val treceiveAddresses = ethereumTransactionsDF.select("ethereumTransactions.receiveAddress").collect
-  val tgasPrices = ethereumTransactionsDF.select("ethereumTransactions.gasPrice").collect
-  val tgasLimits = ethereumTransactionsDF.select("ethereumTransactions.gasLimit").collect
-  val tdatas = ethereumTransactionsDF.select("ethereumTransactions.data").collect
-  val tsigvs = ethereumTransactionsDF.select("ethereumTransactions.sig_v").collect
-  val tsigrs = ethereumTransactionsDF.select("ethereumTransactions.sig_r").collect
-  val tsigss = ethereumTransactionsDF.select("ethereumTransactions.sig_s").collect
-  val tsendAddresses = ethereumTransactionsDF.select("ethereumTransactions.sendAddress").collect
-  val thashes = ethereumTransactionsDF.select("ethereumTransactions.hash").collect
-  var transactNum=0
-  val expectedt1Nonce = Array(0x0C.toByte)
-  assert(expectedt1Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1Value = 1069000990000000000L
-  assert(expectedt1Value==tvalues(transactNum).get(0))
-  val expectedt1ReceiveAddress= Array(0x1E.toByte,0x75.toByte,0xF0.toByte,0x2A.toByte,0x6E.toByte,0x9F.toByte,0xF4.toByte,0xFF.toByte,0x16.toByte,0x33.toByte,0x38.toByte,0x25.toByte,0xD9.toByte,0x09.toByte,0xBB.toByte,0x03.toByte,0x33.toByte,0x06.toByte,0xB7.toByte,0x8B.toByte)
-  assert(expectedt1ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1GasPrice=20000000000L
-  assert(expectedt1GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt1GasLimit=21000
-  assert(expectedt1GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt1Data : Array[Byte] = Array()
-  assert(expectedt1Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1sigv = Array(0x1B.toByte)
-  assert(expectedt1sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1sigr = Array(0x47.toByte,0xDD.toByte,0xF9.toByte,0x37.toByte,0x68.toByte,0x97.toByte,0x76.toByte,0x78.toByte,0x13.toByte,0x95.toByte,0x5A.toByte,0x9D.toByte,0x46.toByte,0xB6.toByte,0xF1.toByte,0xAA.toByte,0x77.toByte,0x73.toByte,0xE5.toByte,0xC8.toByte,0xC6.toByte,0x21.toByte,0x67.toByte,0x54.toByte,0x1C.toByte,0x80.toByte,0xBF.toByte,0x25.toByte,0x2D.toByte,0xC7.toByte,0xDC.toByte,0xD2.toByte)
-  assert(expectedt1sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1sigs = Array(0x0A.toByte,0x31.toByte,0x3F.toByte,0x35.toByte,0x60.toByte,0x32.toByte,0x37.toByte,0x56.toByte,0xB7.toByte,0x28.toByte,0x5F.toByte,0x62.toByte,0x38.toByte,0x51.toByte,0x86.toByte,0x05.toByte,0x82.toByte,0x1A.toByte,0x2B.toByte,0xEE.toByte,0x03.toByte,0x7D.toByte,0xEA.toByte,0x8F.toByte,0x09.toByte,0x22.toByte,0x66.toByte,0x20.toByte,0x89.toByte,0x03.toByte,0x74.toByte,0x59.toByte)
-  assert(expectedt1sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1sendAddress = Array(0x39.toByte,0x42.toByte,0x4B.toByte,0xD2.toByte,0x8A.toByte,0x22.toByte,0x23.toByte,0xDA.toByte,0x3E.toByte,0x14.toByte,0xBF.toByte,0x79.toByte,0x3C.toByte,0xF7.toByte,0xF8.toByte,0x20.toByte,0x8E.toByte,0xE9.toByte,0x98.toByte,0x0A.toByte)
-  assert(expectedt1sendAddress.deep==tsendAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt1hash = Array(0xE2.toByte,0x7E.toByte,0x92.toByte,0x88.toByte,0xE2.toByte,0x9C.toByte,0xC8.toByte,0xEB.toByte,0x78.toByte,0xF9.toByte,0xF7.toByte,0x68.toByte,0xD8.toByte,0x9B.toByte,0xF1.toByte,0xCD.toByte,0x4B.toByte,0x68.toByte,0xB7.toByte,0x15.toByte,0xA3.toByte,0x8B.toByte,0x95.toByte,0xD4.toByte,0x6D.toByte,0x77.toByte,0x86.toByte,0x18.toByte,0xCB.toByte,0x10.toByte,0x4D.toByte,0x58.toByte)
-  assert(expectedt1hash.deep==thashes(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    // check if content is correct
+    // sanity checks
+    assert(6 == ethereumTransactionsDF.count())
+    assert(0 == ethereumUncleHeaderDF.count())
+    // check details
+    // block header
+    val expectedBhParentHash = Array(0xba.toByte, 0x6d.toByte, 0xd2.toByte, 0x60.toByte, 0x12.toByte, 0xb3.toByte, 0x71.toByte, 0x90.toByte, 0x48.toByte, 0xf3.toByte, 0x16.toByte, 0xc6.toByte, 0xed.toByte, 0xb3.toByte, 0x34.toByte, 0x9b.toByte, 0xdf.toByte, 0xbd.toByte, 0x61.toByte, 0x31.toByte, 0x9f.toByte, 0xa9.toByte, 0x7c.toByte, 0x61.toByte, 0x6a.toByte, 0x61.toByte, 0x31.toByte, 0x18.toByte, 0xa1.toByte, 0xaf.toByte, 0x30.toByte, 0x67.toByte)
+    val bhParentHash = df.select("ethereumBlockHeader.parentHash").collect
+    assert(expectedBhParentHash.deep == bhParentHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectdBhUncleHash = Array(0x1D.toByte, 0xCC.toByte, 0x4D.toByte, 0xE8.toByte, 0xDE.toByte, 0xC7.toByte, 0x5D.toByte, 0x7A.toByte, 0xAB.toByte, 0x85.toByte, 0xB5.toByte, 0x67.toByte, 0xB6.toByte, 0xCC.toByte, 0xD4.toByte, 0x1A.toByte, 0xD3.toByte, 0x12.toByte, 0x45.toByte, 0x1B.toByte, 0x94.toByte, 0x8A.toByte, 0x74.toByte, 0x13.toByte, 0xF0.toByte, 0xA1.toByte, 0x42.toByte, 0xFD.toByte, 0x40.toByte, 0xD4.toByte, 0x93.toByte, 0x47.toByte)
+    val bhUncleHash = df.select("ethereumBlockHeader.uncleHash").collect
+    assert(expectdBhUncleHash.deep == bhUncleHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhCoinBase = Array(0x1A.toByte, 0x06.toByte, 0x0B.toByte, 0x06.toByte, 0x04.toByte, 0x88.toByte, 0x3A.toByte, 0x99.toByte, 0x80.toByte, 0x9E.toByte, 0xB3.toByte, 0xF7.toByte, 0x98.toByte, 0xDF.toByte, 0x71.toByte, 0xBE.toByte, 0xF6.toByte, 0xC3.toByte, 0x58.toByte, 0xF1.toByte)
+    val bhCoinBase = df.select("ethereumBlockHeader.coinBase").collect
+    assert(expectedBhCoinBase.deep == bhCoinBase(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhStateRoot = Array(0x21.toByte, 0xBA.toByte, 0x88.toByte, 0x6F.toByte, 0xD2.toByte, 0x6F.toByte, 0x17.toByte, 0xB4.toByte, 0x01.toByte, 0xF5.toByte, 0x39.toByte, 0x20.toByte, 0x15.toByte, 0x33.toByte, 0x10.toByte, 0xB6.toByte, 0x93.toByte, 0x9B.toByte, 0xAD.toByte, 0x8A.toByte, 0x5F.toByte, 0xC3.toByte, 0xBF.toByte, 0x8C.toByte, 0x50.toByte, 0x5C.toByte, 0x55.toByte, 0x6D.toByte, 0xDB.toByte, 0xAF.toByte, 0xBC.toByte, 0x5C.toByte)
+    val bhStateRoot = df.select("ethereumBlockHeader.stateRoot").collect
+    assert(expectedBhStateRoot.deep == bhStateRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhTxTrieRoot = Array(0xB3.toByte, 0xCB.toByte, 0xC7.toByte, 0xF0.toByte, 0xD7.toByte, 0x87.toByte, 0xE5.toByte, 0x7D.toByte, 0x93.toByte, 0x70.toByte, 0xB8.toByte, 0x02.toByte, 0xAB.toByte, 0x94.toByte, 0x5E.toByte, 0x21.toByte, 0x99.toByte, 0x1C.toByte, 0x3E.toByte, 0x12.toByte, 0x7D.toByte, 0x70.toByte, 0x12.toByte, 0x0C.toByte, 0x37.toByte, 0xE9.toByte, 0xFD.toByte, 0xAE.toByte, 0x3E.toByte, 0xF3.toByte, 0xEB.toByte, 0xFC.toByte)
+    val bhTxTrieRoot = df.select("ethereumBlockHeader.txTrieRoot").collect
+    assert(expectedBhTxTrieRoot.deep == bhTxTrieRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhReceiptTrieRoot = Array(0x9B.toByte, 0xCE.toByte, 0x71.toByte, 0x32.toByte, 0xF5.toByte, 0x2D.toByte, 0x4D.toByte, 0x45.toByte, 0xA8.toByte, 0xA2.toByte, 0x47.toByte, 0x48.toByte, 0x47.toByte, 0x86.toByte, 0xC7.toByte, 0x0B.toByte, 0xB2.toByte, 0xE6.toByte, 0x39.toByte, 0x59.toByte, 0xC8.toByte, 0x56.toByte, 0x1B.toByte, 0x3A.toByte, 0xBF.toByte, 0xD4.toByte, 0xE7.toByte, 0x22.toByte, 0xE6.toByte, 0x00.toByte, 0x6A.toByte, 0x27.toByte)
+    val bhReceiptTrieRoot = df.select("ethereumBlockHeader.receiptTrieRoot").collect
+    assert(expectedBhReceiptTrieRoot.deep == bhReceiptTrieRoot(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhLogsBloom = Array(0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte, 0x00.toByte)
+    val bhLogsBloom = df.select("ethereumBlockHeader.logsBloom").collect
+    assert(expectedBhLogsBloom.deep == bhLogsBloom(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhDifficulty = Array(0x19.toByte, 0xFF.toByte, 0x9E.toByte, 0xC4.toByte, 0x35.toByte, 0xE0.toByte)
+    val bhDifficulty = df.select("ethereumBlockHeader.difficulty").collect
+    assert(expectedBhDifficulty.deep == bhDifficulty(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val format = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z")
+    val expectedDTStr = "16-04-2016 09:34:29 UTC"
+    val expectedBhTimestamp = format.parse(expectedDTStr).getTime / 1000
+    val bhTimestamp = df.select("ethereumBlockHeader.timestamp").collect
+    assert(expectedBhTimestamp == bhTimestamp(0).get(0))
+    val expectedBhNumber = 1346406
+    val bhNumber = df.select("ethereumBlockHeader.number").collect
+    assert(expectedBhNumber == bhNumber(0).get(0))
+    val expectedBhGasLimit = 4712388
+    val bhGasLimit = df.select("ethereumBlockHeader.gasLimit").collect
+    assert(expectedBhGasLimit == bhGasLimit(0).get(0))
+    val expectedBhGasUsed = 126000
+    val bhGasUsed = df.select("ethereumBlockHeader.gasUsed").collect
+    assert(expectedBhGasUsed == bhGasUsed(0).get(0))
+    val expectedBhMixHash = Array(0x4F.toByte, 0x57.toByte, 0x71.toByte, 0xB7.toByte, 0x9A.toByte, 0x8E.toByte, 0x6E.toByte, 0x21.toByte, 0x99.toByte, 0x35.toByte, 0x53.toByte, 0x9C.toByte, 0x47.toByte, 0x3E.toByte, 0x23.toByte, 0xBA.toByte, 0xFD.toByte, 0x2C.toByte, 0xA3.toByte, 0x5C.toByte, 0xC1.toByte, 0x86.toByte, 0x20.toByte, 0x66.toByte, 0x31.toByte, 0xC3.toByte, 0xB0.toByte, 0x9E.toByte, 0xD5.toByte, 0x76.toByte, 0x19.toByte, 0x4A.toByte)
+    val bhMixHash = df.select("ethereumBlockHeader.mixHash").collect
+    assert(expectedBhMixHash.deep == bhMixHash(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhExtraData = Array(0xD7.toByte, 0x83.toByte, 0x01.toByte, 0x03.toByte, 0x05.toByte, 0x84.toByte, 0x47.toByte, 0x65.toByte, 0x74.toByte, 0x68.toByte, 0x87.toByte, 0x67.toByte, 0x6F.toByte, 0x31.toByte, 0x2E.toByte, 0x35.toByte, 0x2E.toByte, 0x31.toByte, 0x85.toByte, 0x6C.toByte, 0x69.toByte, 0x6E.toByte, 0x75.toByte, 0x78.toByte)
+    val bhExtraData = df.select("ethereumBlockHeader.extraData").collect
+    assert(expectedBhExtraData.deep == bhExtraData(0).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedBhNonce = Array(0xFF.toByte, 0x7C.toByte, 0x7A.toByte, 0xEE.toByte, 0x0E.toByte, 0x88.toByte, 0xC5.toByte, 0x2D.toByte)
+    val bhNonce = df.select("ethereumBlockHeader.nonce").collect
+    assert(expectedBhNonce.deep == bhNonce(0).get(0).asInstanceOf[Array[Byte]].deep)
+    // transactions
+    val tnonces = ethereumTransactionsDF.select("ethereumTransactions.nonce").collect
+    val tvalues = ethereumTransactionsDF.select("ethereumTransactions.value").collect
+    val treceiveAddresses = ethereumTransactionsDF.select("ethereumTransactions.receiveAddress").collect
+    val tgasPrices = ethereumTransactionsDF.select("ethereumTransactions.gasPrice").collect
+    val tgasLimits = ethereumTransactionsDF.select("ethereumTransactions.gasLimit").collect
+    val tdatas = ethereumTransactionsDF.select("ethereumTransactions.data").collect
+    val tsigvs = ethereumTransactionsDF.select("ethereumTransactions.sig_v").collect
+    val tsigrs = ethereumTransactionsDF.select("ethereumTransactions.sig_r").collect
+    val tsigss = ethereumTransactionsDF.select("ethereumTransactions.sig_s").collect
+    val tsendAddresses = ethereumTransactionsDF.select("ethereumTransactions.sendAddress").collect
+    val thashes = ethereumTransactionsDF.select("ethereumTransactions.hash").collect
+    var transactNum = 0
+    val expectedt1Nonce = Array(0x0C.toByte)
+    assert(expectedt1Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1Value = 1069000990000000000L
+    assert(expectedt1Value == tvalues(transactNum).get(0))
+    val expectedt1ReceiveAddress = Array(0x1E.toByte, 0x75.toByte, 0xF0.toByte, 0x2A.toByte, 0x6E.toByte, 0x9F.toByte, 0xF4.toByte, 0xFF.toByte, 0x16.toByte, 0x33.toByte, 0x38.toByte, 0x25.toByte, 0xD9.toByte, 0x09.toByte, 0xBB.toByte, 0x03.toByte, 0x33.toByte, 0x06.toByte, 0xB7.toByte, 0x8B.toByte)
+    assert(expectedt1ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1GasPrice = 20000000000L
+    assert(expectedt1GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt1GasLimit = 21000
+    assert(expectedt1GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt1Data: Array[Byte] = Array()
+    assert(expectedt1Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1sigv = Array(0x1B.toByte)
+    assert(expectedt1sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1sigr = Array(0x47.toByte, 0xDD.toByte, 0xF9.toByte, 0x37.toByte, 0x68.toByte, 0x97.toByte, 0x76.toByte, 0x78.toByte, 0x13.toByte, 0x95.toByte, 0x5A.toByte, 0x9D.toByte, 0x46.toByte, 0xB6.toByte, 0xF1.toByte, 0xAA.toByte, 0x77.toByte, 0x73.toByte, 0xE5.toByte, 0xC8.toByte, 0xC6.toByte, 0x21.toByte, 0x67.toByte, 0x54.toByte, 0x1C.toByte, 0x80.toByte, 0xBF.toByte, 0x25.toByte, 0x2D.toByte, 0xC7.toByte, 0xDC.toByte, 0xD2.toByte)
+    assert(expectedt1sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1sigs = Array(0x0A.toByte, 0x31.toByte, 0x3F.toByte, 0x35.toByte, 0x60.toByte, 0x32.toByte, 0x37.toByte, 0x56.toByte, 0xB7.toByte, 0x28.toByte, 0x5F.toByte, 0x62.toByte, 0x38.toByte, 0x51.toByte, 0x86.toByte, 0x05.toByte, 0x82.toByte, 0x1A.toByte, 0x2B.toByte, 0xEE.toByte, 0x03.toByte, 0x7D.toByte, 0xEA.toByte, 0x8F.toByte, 0x09.toByte, 0x22.toByte, 0x66.toByte, 0x20.toByte, 0x89.toByte, 0x03.toByte, 0x74.toByte, 0x59.toByte)
+    assert(expectedt1sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1sendAddress = Array(0x39.toByte, 0x42.toByte, 0x4B.toByte, 0xD2.toByte, 0x8A.toByte, 0x22.toByte, 0x23.toByte, 0xDA.toByte, 0x3E.toByte, 0x14.toByte, 0xBF.toByte, 0x79.toByte, 0x3C.toByte, 0xF7.toByte, 0xF8.toByte, 0x20.toByte, 0x8E.toByte, 0xE9.toByte, 0x98.toByte, 0x0A.toByte)
+    assert(expectedt1sendAddress.deep == tsendAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt1hash = Array(0xE2.toByte, 0x7E.toByte, 0x92.toByte, 0x88.toByte, 0xE2.toByte, 0x9C.toByte, 0xC8.toByte, 0xEB.toByte, 0x78.toByte, 0xF9.toByte, 0xF7.toByte, 0x68.toByte, 0xD8.toByte, 0x9B.toByte, 0xF1.toByte, 0xCD.toByte, 0x4B.toByte, 0x68.toByte, 0xB7.toByte, 0x15.toByte, 0xA3.toByte, 0x8B.toByte, 0x95.toByte, 0xD4.toByte, 0x6D.toByte, 0x77.toByte, 0x86.toByte, 0x18.toByte, 0xCB.toByte, 0x10.toByte, 0x4D.toByte, 0x58.toByte)
+    assert(expectedt1hash.deep == thashes(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
 
-  transactNum=1
-  val expectedt2Nonce = Array(0xFF.toByte,0xD7.toByte)
-  assert(expectedt2Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2Value = 5110508700000000000L
-  assert(expectedt2Value==tvalues(transactNum).get(0))
-  val expectedt2ReceiveAddress= Array(0x54.toByte,0x67.toByte,0xFA.toByte,0xBD.toByte,0x30.toByte,0xEB.toByte,0x61.toByte,0xA1.toByte,0x84.toByte,0x61.toByte,0xD1.toByte,0x53.toByte,0xD8.toByte,0xC6.toByte,0xFF.toByte,0xB1.toByte,0x9D.toByte,0xD4.toByte,0x7A.toByte,0x25.toByte)
-  assert(expectedt2ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2GasPrice=20000000000L
-  assert(expectedt2GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt2GasLimit=90000
-  assert(expectedt2GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt2Data : Array[Byte] = Array()
-  assert(expectedt2Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2sigv = Array(0x1B.toByte)
-  assert(expectedt2sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2sigr = Array(0x62.toByte,0x85.toByte,0x3C.toByte,0x63.toByte,0x9A.toByte,0x9B.toByte,0x9E.toByte,0xC4.toByte,0x9B.toByte,0xA9.toByte,0xAC.toByte,0x53.toByte,0xE2.toByte,0x85.toByte,0xB3.toByte,0x4E.toByte,0xD0.toByte,0xB7.toByte,0x65.toByte,0x5C.toByte,0x1B.toByte,0xE3.toByte,0x29.toByte,0xFB.toByte,0x8B.toByte,0x34.toByte,0x70.toByte,0x74.toByte,0x0C.toByte,0x3D.toByte,0x0A.toByte,0x9A.toByte)
-   assert(expectedt2sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2sigs =  Array(0x03.toByte,0xFA.toByte,0xA6.toByte,0xF4.toByte,0xFF.toByte,0x1A.toByte,0x45.toByte,0x76.toByte,0xDF.toByte,0x08.toByte,0x9A.toByte,0x9F.toByte,0x9C.toByte,0xB7.toByte,0x9C.toByte,0xF2.toByte,0xED.toByte,0xC1.toByte,0xC5.toByte,0xBD.toByte,0xEC.toByte,0x0F.toByte,0xE7.toByte,0x9C.toByte,0x79.toByte,0x2A.toByte,0xCB.toByte,0x9E.toByte,0x83.toByte,0xF2.toByte,0x41.toByte)
-  assert(expectedt2sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2sendAddress =  Array(0x4B.toByte,0xB9.toByte,0x60.toByte,0x91.toByte,0xEE.toByte,0x9D.toByte,0x80.toByte,0x2E.toByte,0xD0.toByte,0x39.toByte,0xC4.toByte,0xD1.toByte,0xA5.toByte,0xF6.toByte,0x21.toByte,0x6F.toByte,0x90.toByte,0xF8.toByte,0x1B.toByte,0x01.toByte)
-     assert(expectedt2sendAddress.deep==tsendAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt2hash =  Array(0x7A.toByte,0x23.toByte,0x2A.toByte,0xA2.toByte,0xAE.toByte,0x6A.toByte,0x5E.toByte,0x1F.toByte,0x32.toByte,0xCA.toByte,0x3A.toByte,0xC9.toByte,0x3F.toByte,0x4F.toByte,0xDB.toByte,0x77.toByte,0x98.toByte,0x3E.toByte,0x93.toByte,0x2B.toByte,0x38.toByte,0x09.toByte,0x93.toByte,0x56.toByte,0x44.toByte,0x42.toByte,0x08.toByte,0xC6.toByte,0x9D.toByte,0x40.toByte,0x86.toByte,0x81.toByte)
-   assert(expectedt2hash.deep==thashes(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 1
+    val expectedt2Nonce = Array(0xFF.toByte, 0xD7.toByte)
+    assert(expectedt2Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2Value = 5110508700000000000L
+    assert(expectedt2Value == tvalues(transactNum).get(0))
+    val expectedt2ReceiveAddress = Array(0x54.toByte, 0x67.toByte, 0xFA.toByte, 0xBD.toByte, 0x30.toByte, 0xEB.toByte, 0x61.toByte, 0xA1.toByte, 0x84.toByte, 0x61.toByte, 0xD1.toByte, 0x53.toByte, 0xD8.toByte, 0xC6.toByte, 0xFF.toByte, 0xB1.toByte, 0x9D.toByte, 0xD4.toByte, 0x7A.toByte, 0x25.toByte)
+    assert(expectedt2ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2GasPrice = 20000000000L
+    assert(expectedt2GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt2GasLimit = 90000
+    assert(expectedt2GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt2Data: Array[Byte] = Array()
+    assert(expectedt2Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2sigv = Array(0x1B.toByte)
+    assert(expectedt2sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2sigr = Array(0x62.toByte, 0x85.toByte, 0x3C.toByte, 0x63.toByte, 0x9A.toByte, 0x9B.toByte, 0x9E.toByte, 0xC4.toByte, 0x9B.toByte, 0xA9.toByte, 0xAC.toByte, 0x53.toByte, 0xE2.toByte, 0x85.toByte, 0xB3.toByte, 0x4E.toByte, 0xD0.toByte, 0xB7.toByte, 0x65.toByte, 0x5C.toByte, 0x1B.toByte, 0xE3.toByte, 0x29.toByte, 0xFB.toByte, 0x8B.toByte, 0x34.toByte, 0x70.toByte, 0x74.toByte, 0x0C.toByte, 0x3D.toByte, 0x0A.toByte, 0x9A.toByte)
+    assert(expectedt2sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2sigs = Array(0x03.toByte, 0xFA.toByte, 0xA6.toByte, 0xF4.toByte, 0xFF.toByte, 0x1A.toByte, 0x45.toByte, 0x76.toByte, 0xDF.toByte, 0x08.toByte, 0x9A.toByte, 0x9F.toByte, 0x9C.toByte, 0xB7.toByte, 0x9C.toByte, 0xF2.toByte, 0xED.toByte, 0xC1.toByte, 0xC5.toByte, 0xBD.toByte, 0xEC.toByte, 0x0F.toByte, 0xE7.toByte, 0x9C.toByte, 0x79.toByte, 0x2A.toByte, 0xCB.toByte, 0x9E.toByte, 0x83.toByte, 0xF2.toByte, 0x41.toByte)
+    assert(expectedt2sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2sendAddress = Array(0x4B.toByte, 0xB9.toByte, 0x60.toByte, 0x91.toByte, 0xEE.toByte, 0x9D.toByte, 0x80.toByte, 0x2E.toByte, 0xD0.toByte, 0x39.toByte, 0xC4.toByte, 0xD1.toByte, 0xA5.toByte, 0xF6.toByte, 0x21.toByte, 0x6F.toByte, 0x90.toByte, 0xF8.toByte, 0x1B.toByte, 0x01.toByte)
+    assert(expectedt2sendAddress.deep == tsendAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt2hash = Array(0x7A.toByte, 0x23.toByte, 0x2A.toByte, 0xA2.toByte, 0xAE.toByte, 0x6A.toByte, 0x5E.toByte, 0x1F.toByte, 0x32.toByte, 0xCA.toByte, 0x3A.toByte, 0xC9.toByte, 0x3F.toByte, 0x4F.toByte, 0xDB.toByte, 0x77.toByte, 0x98.toByte, 0x3E.toByte, 0x93.toByte, 0x2B.toByte, 0x38.toByte, 0x09.toByte, 0x93.toByte, 0x56.toByte, 0x44.toByte, 0x42.toByte, 0x08.toByte, 0xC6.toByte, 0x9D.toByte, 0x40.toByte, 0x86.toByte, 0x81.toByte)
+    assert(expectedt2hash.deep == thashes(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
 
-  transactNum=2
-  val expectedt3Nonce = Array(0x02.toByte,0xD7.toByte,0xDD.toByte)
-  assert(expectedt3Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3Value = 11667800000000000L
-  assert(expectedt3Value==tvalues(transactNum).get(0))
-  val expectedt3ReceiveAddress= Array(0xB4.toByte,0xD0.toByte,0xCA.toByte,0x2B.toByte,0x7E.toByte,0x4C.toByte,0xB1.toByte,0xE0.toByte,0x61.toByte,0x0D.toByte,0x02.toByte,0x15.toByte,0x4A.toByte,0x10.toByte,0x16.toByte,0x3A.toByte,0xB0.toByte,0xF4.toByte,0x2E.toByte,0x65.toByte)
-     assert(expectedt3ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3GasPrice=20000000000L
-  assert(expectedt3GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt3GasLimit=90000
-  assert(expectedt3GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt3Data : Array[Byte] = Array()
-  assert(expectedt3Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3sigv = Array(0x1C.toByte)
-  assert(expectedt3sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3sigr = Array(0x89.toByte,0xFD.toByte,0x7A.toByte,0x62.toByte,0xCF.toByte,0x44.toByte,0x77.toByte,0xBF.toByte,0xE5.toByte,0xDB.toByte,0xF0.toByte,0xEE.toByte,0xCF.toByte,0x3A.toByte,0x4A.toByte,0x96.toByte,0x71.toByte,0x96.toByte,0x96.toByte,0xFB.toByte,0xBE.toByte,0x16.toByte,0xBA.toByte,0x0A.toByte,0xBA.toByte,0x1D.toByte,0x63.toByte,0x1D.toByte,0x44.toByte,0xC1.toByte,0xEB.toByte,0x58.toByte)
-   assert(expectedt3sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3sigs =  Array(0x24.toByte,0x34.toByte,0x48.toByte,0x64.toByte,0xEB.toByte,0x6A.toByte,0x60.toByte,0xC6.toByte,0x6F.toByte,0xB5.toByte,0xDA.toByte,0xED.toByte,0x02.toByte,0xB5.toByte,0x63.toByte,0x52.toByte,0xE8.toByte,0x17.toByte,0x42.toByte,0x16.toByte,0xB8.toByte,0xA2.toByte,0xD3.toByte,0x33.toByte,0xB7.toByte,0xF3.toByte,0x32.toByte,0xFF.toByte,0x6B.toByte,0xA0.toByte,0x69.toByte,0x9C.toByte)
-  assert(expectedt3sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3sendAddress = Array(0x63.toByte,0xA9.toByte,0x97.toByte,0x5B.toByte,0xA3.toByte,0x1B.toByte,0x0B.toByte,0x96.toByte,0x26.toByte,0xB3.toByte,0x43.toByte,0x00.toByte,0xF7.toByte,0xF6.toByte,0x27.toByte,0x14.toByte,0x7D.toByte,0xF1.toByte,0xF5.toByte,0x26.toByte)
-     assert(expectedt3sendAddress.deep==tsendAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt3hash = Array(0x14.toByte,0x33.toByte,0xE3.toByte,0xCB.toByte,0x66.toByte,0x2F.toByte,0x66.toByte,0x8D.toByte,0x87.toByte,0xB8.toByte,0x35.toByte,0x55.toByte,0x34.toByte,0x5A.toByte,0x20.toByte,0xCC.toByte,0xF8.toByte,0x70.toByte,0x6F.toByte,0x25.toByte,0x21.toByte,0x49.toByte,0x18.toByte,0xE2.toByte,0xF8.toByte,0x1F.toByte,0xE3.toByte,0xD2.toByte,0x1C.toByte,0x9D.toByte,0x5B.toByte,0x23.toByte)
-      assert(expectedt3hash.deep==thashes(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 2
+    val expectedt3Nonce = Array(0x02.toByte, 0xD7.toByte, 0xDD.toByte)
+    assert(expectedt3Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3Value = 11667800000000000L
+    assert(expectedt3Value == tvalues(transactNum).get(0))
+    val expectedt3ReceiveAddress = Array(0xB4.toByte, 0xD0.toByte, 0xCA.toByte, 0x2B.toByte, 0x7E.toByte, 0x4C.toByte, 0xB1.toByte, 0xE0.toByte, 0x61.toByte, 0x0D.toByte, 0x02.toByte, 0x15.toByte, 0x4A.toByte, 0x10.toByte, 0x16.toByte, 0x3A.toByte, 0xB0.toByte, 0xF4.toByte, 0x2E.toByte, 0x65.toByte)
+    assert(expectedt3ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3GasPrice = 20000000000L
+    assert(expectedt3GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt3GasLimit = 90000
+    assert(expectedt3GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt3Data: Array[Byte] = Array()
+    assert(expectedt3Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3sigv = Array(0x1C.toByte)
+    assert(expectedt3sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3sigr = Array(0x89.toByte, 0xFD.toByte, 0x7A.toByte, 0x62.toByte, 0xCF.toByte, 0x44.toByte, 0x77.toByte, 0xBF.toByte, 0xE5.toByte, 0xDB.toByte, 0xF0.toByte, 0xEE.toByte, 0xCF.toByte, 0x3A.toByte, 0x4A.toByte, 0x96.toByte, 0x71.toByte, 0x96.toByte, 0x96.toByte, 0xFB.toByte, 0xBE.toByte, 0x16.toByte, 0xBA.toByte, 0x0A.toByte, 0xBA.toByte, 0x1D.toByte, 0x63.toByte, 0x1D.toByte, 0x44.toByte, 0xC1.toByte, 0xEB.toByte, 0x58.toByte)
+    assert(expectedt3sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3sigs = Array(0x24.toByte, 0x34.toByte, 0x48.toByte, 0x64.toByte, 0xEB.toByte, 0x6A.toByte, 0x60.toByte, 0xC6.toByte, 0x6F.toByte, 0xB5.toByte, 0xDA.toByte, 0xED.toByte, 0x02.toByte, 0xB5.toByte, 0x63.toByte, 0x52.toByte, 0xE8.toByte, 0x17.toByte, 0x42.toByte, 0x16.toByte, 0xB8.toByte, 0xA2.toByte, 0xD3.toByte, 0x33.toByte, 0xB7.toByte, 0xF3.toByte, 0x32.toByte, 0xFF.toByte, 0x6B.toByte, 0xA0.toByte, 0x69.toByte, 0x9C.toByte)
+    assert(expectedt3sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3sendAddress = Array(0x63.toByte, 0xA9.toByte, 0x97.toByte, 0x5B.toByte, 0xA3.toByte, 0x1B.toByte, 0x0B.toByte, 0x96.toByte, 0x26.toByte, 0xB3.toByte, 0x43.toByte, 0x00.toByte, 0xF7.toByte, 0xF6.toByte, 0x27.toByte, 0x14.toByte, 0x7D.toByte, 0xF1.toByte, 0xF5.toByte, 0x26.toByte)
+    assert(expectedt3sendAddress.deep == tsendAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt3hash = Array(0x14.toByte, 0x33.toByte, 0xE3.toByte, 0xCB.toByte, 0x66.toByte, 0x2F.toByte, 0x66.toByte, 0x8D.toByte, 0x87.toByte, 0xB8.toByte, 0x35.toByte, 0x55.toByte, 0x34.toByte, 0x5A.toByte, 0x20.toByte, 0xCC.toByte, 0xF8.toByte, 0x70.toByte, 0x6F.toByte, 0x25.toByte, 0x21.toByte, 0x49.toByte, 0x18.toByte, 0xE2.toByte, 0xF8.toByte, 0x1F.toByte, 0xE3.toByte, 0xD2.toByte, 0x1C.toByte, 0x9D.toByte, 0x5B.toByte, 0x23.toByte)
+    assert(expectedt3hash.deep == thashes(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
 
-  transactNum=3
-  val expectedt4Nonce = Array(0x02.toByte,0xD7.toByte,0xDE.toByte)
-  assert(expectedt4Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4Value = 130970170000000000L
-  assert(expectedt4Value==tvalues(transactNum).get(0))
-  val expectedt4ReceiveAddress= Array(0x1F.toByte,0x57.toByte,0xF8.toByte,0x26.toByte,0xCA.toByte,0xF5.toByte,0x94.toByte,0xF7.toByte,0xA8.toByte,0x37.toByte,0xD9.toByte,0xFC.toByte,0x09.toByte,0x24.toByte,0x56.toByte,0x87.toByte,0x0A.toByte,0x28.toByte,0x93.toByte,0x65.toByte)
-     assert(expectedt4ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4GasPrice=20000000000L
-  assert(expectedt4GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt4GasLimit=90000
-  assert(expectedt4GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt4Data : Array[Byte] = Array()
-  assert(expectedt4Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4sigv = Array(0x1B.toByte)
-  assert(expectedt4sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4sigr = Array(0x46.toByte,0x01.toByte,0x57.toByte,0xDC.toByte,0xE4.toByte,0xE9.toByte,0x5D.toByte,0x1D.toByte,0xCC.toByte,0x7A.toByte,0xED.toByte,0x0D.toByte,0x9B.toByte,0x7E.toByte,0x3D.toByte,0x65.toByte,0x37.toByte,0x0C.toByte,0x53.toByte,0xD2.toByte,0x9E.toByte,0xA9.toByte,0xB1.toByte,0xAA.toByte,0x4C.toByte,0x9C.toByte,0x22.toByte,0x14.toByte,0x91.toByte,0x1C.toByte,0xD9.toByte,0x5E.toByte)
-    assert(expectedt4sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4sigs = Array(0x6A.toByte,0x84.toByte,0x4F.toByte,0x95.toByte,0x6D.toByte,0x02.toByte,0x46.toByte,0x94.toByte,0x1B.toByte,0x94.toByte,0x30.toByte,0x91.toByte,0x34.toByte,0x21.toByte,0x20.toByte,0xBD.toByte,0x48.toByte,0xE7.toByte,0xC6.toByte,0x35.toByte,0x77.toByte,0xF0.toByte,0xBA.toByte,0x3D.toByte,0x87.toByte,0x59.toByte,0xC9.toByte,0xEC.toByte,0x58.toByte,0x70.toByte,0x4E.toByte,0xEC.toByte)
-    assert(expectedt4sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4sendAddress = Array(0x63.toByte,0xA9.toByte,0x97.toByte,0x5B.toByte,0xA3.toByte,0x1B.toByte,0x0B.toByte,0x96.toByte,0x26.toByte,0xB3.toByte,0x43.toByte,0x00.toByte,0xF7.toByte,0xF6.toByte,0x27.toByte,0x14.toByte,0x7D.toByte,0xF1.toByte,0xF5.toByte,0x26.toByte)
-     assert(expectedt4sendAddress.deep==tsendAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt4hash = Array(0x39.toByte,0x22.toByte,0xF7.toByte,0xF6.toByte,0x0A.toByte,0x33.toByte,0xA1.toByte,0x2D.toByte,0x13.toByte,0x9D.toByte,0x67.toByte,0xFA.toByte,0x53.toByte,0x30.toByte,0xDB.toByte,0xFD.toByte,0xBA.toByte,0x42.toByte,0xA4.toByte,0xB7.toByte,0x67.toByte,0x29.toByte,0x6E.toByte,0xFF.toByte,0x64.toByte,0x15.toByte,0xEE.toByte,0xA3.toByte,0x2D.toByte,0x8A.toByte,0x7B.toByte,0x2B.toByte)
-   assert(expectedt4hash.deep==thashes(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 3
+    val expectedt4Nonce = Array(0x02.toByte, 0xD7.toByte, 0xDE.toByte)
+    assert(expectedt4Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4Value = 130970170000000000L
+    assert(expectedt4Value == tvalues(transactNum).get(0))
+    val expectedt4ReceiveAddress = Array(0x1F.toByte, 0x57.toByte, 0xF8.toByte, 0x26.toByte, 0xCA.toByte, 0xF5.toByte, 0x94.toByte, 0xF7.toByte, 0xA8.toByte, 0x37.toByte, 0xD9.toByte, 0xFC.toByte, 0x09.toByte, 0x24.toByte, 0x56.toByte, 0x87.toByte, 0x0A.toByte, 0x28.toByte, 0x93.toByte, 0x65.toByte)
+    assert(expectedt4ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4GasPrice = 20000000000L
+    assert(expectedt4GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt4GasLimit = 90000
+    assert(expectedt4GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt4Data: Array[Byte] = Array()
+    assert(expectedt4Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4sigv = Array(0x1B.toByte)
+    assert(expectedt4sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4sigr = Array(0x46.toByte, 0x01.toByte, 0x57.toByte, 0xDC.toByte, 0xE4.toByte, 0xE9.toByte, 0x5D.toByte, 0x1D.toByte, 0xCC.toByte, 0x7A.toByte, 0xED.toByte, 0x0D.toByte, 0x9B.toByte, 0x7E.toByte, 0x3D.toByte, 0x65.toByte, 0x37.toByte, 0x0C.toByte, 0x53.toByte, 0xD2.toByte, 0x9E.toByte, 0xA9.toByte, 0xB1.toByte, 0xAA.toByte, 0x4C.toByte, 0x9C.toByte, 0x22.toByte, 0x14.toByte, 0x91.toByte, 0x1C.toByte, 0xD9.toByte, 0x5E.toByte)
+    assert(expectedt4sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4sigs = Array(0x6A.toByte, 0x84.toByte, 0x4F.toByte, 0x95.toByte, 0x6D.toByte, 0x02.toByte, 0x46.toByte, 0x94.toByte, 0x1B.toByte, 0x94.toByte, 0x30.toByte, 0x91.toByte, 0x34.toByte, 0x21.toByte, 0x20.toByte, 0xBD.toByte, 0x48.toByte, 0xE7.toByte, 0xC6.toByte, 0x35.toByte, 0x77.toByte, 0xF0.toByte, 0xBA.toByte, 0x3D.toByte, 0x87.toByte, 0x59.toByte, 0xC9.toByte, 0xEC.toByte, 0x58.toByte, 0x70.toByte, 0x4E.toByte, 0xEC.toByte)
+    assert(expectedt4sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4sendAddress = Array(0x63.toByte, 0xA9.toByte, 0x97.toByte, 0x5B.toByte, 0xA3.toByte, 0x1B.toByte, 0x0B.toByte, 0x96.toByte, 0x26.toByte, 0xB3.toByte, 0x43.toByte, 0x00.toByte, 0xF7.toByte, 0xF6.toByte, 0x27.toByte, 0x14.toByte, 0x7D.toByte, 0xF1.toByte, 0xF5.toByte, 0x26.toByte)
+    assert(expectedt4sendAddress.deep == tsendAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt4hash = Array(0x39.toByte, 0x22.toByte, 0xF7.toByte, 0xF6.toByte, 0x0A.toByte, 0x33.toByte, 0xA1.toByte, 0x2D.toByte, 0x13.toByte, 0x9D.toByte, 0x67.toByte, 0xFA.toByte, 0x53.toByte, 0x30.toByte, 0xDB.toByte, 0xFD.toByte, 0xBA.toByte, 0x42.toByte, 0xA4.toByte, 0xB7.toByte, 0x67.toByte, 0x29.toByte, 0x6E.toByte, 0xFF.toByte, 0x64.toByte, 0x15.toByte, 0xEE.toByte, 0xA3.toByte, 0x2D.toByte, 0x8A.toByte, 0x7B.toByte, 0x2B.toByte)
+    assert(expectedt4hash.deep == thashes(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
 
-  transactNum=4
-  val expectedt5Nonce = Array(0x02.toByte,0xD7.toByte,0xDF.toByte)
-  assert(expectedt5Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5Value = 144683800000000000L
-  assert(expectedt5Value==tvalues(transactNum).get(0))
-  val expectedt5ReceiveAddress= Array(0x1F.toByte,0x57.toByte,0xF8.toByte,0x26.toByte,0xCA.toByte,0xF5.toByte,0x94.toByte,0xF7.toByte,0xA8.toByte,0x37.toByte,0xD9.toByte,0xFC.toByte,0x09.toByte,0x24.toByte,0x56.toByte,0x87.toByte,0x0A.toByte,0x28.toByte,0x93.toByte,0x65.toByte)
-  assert(expectedt5ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5GasPrice=20000000000L
-  assert(expectedt5GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt5GasLimit=90000
-  assert(expectedt5GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt5Data : Array[Byte] = Array()
-  assert(expectedt5Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5sigv = Array(0x1C.toByte)
-  assert(expectedt5sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5sigr = Array(0xE4.toByte,0xBE.toByte,0x97.toByte,0xD5.toByte,0xAF.toByte,0xF1.toByte,0xB5.toByte,0xE7.toByte,0x99.toByte,0x12.toByte,0x96.toByte,0x98.toByte,0x2B.toByte,0xDF.toByte,0xC1.toByte,0xC2.toByte,0x2F.toByte,0x75.toByte,0x21.toByte,0x13.toByte,0x4F.toByte,0x7E.toByte,0x1A.toByte,0x9D.toByte,0xA3.toByte,0x00.toByte,0x42.toByte,0x0D.toByte,0xAD.toByte,0x33.toByte,0x6F.toByte,0x34.toByte)
-    assert(expectedt5sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5sigs = Array(0x62.toByte,0xDE.toByte,0xF8.toByte,0xAA.toByte,0x83.toByte,0x65.toByte,0x58.toByte,0xC7.toByte,0xB0.toByte,0xA5.toByte,0x65.toByte,0xB9.toByte,0x7C.toByte,0x9B.toByte,0x27.toByte,0xB2.toByte,0x0E.toByte,0xD9.toByte,0xA0.toByte,0x51.toByte,0xDE.toByte,0x22.toByte,0xAD.toByte,0x8D.toByte,0xBD.toByte,0x62.toByte,0x52.toByte,0x44.toByte,0xCE.toByte,0x64.toByte,0x9E.toByte,0x3D.toByte)
-     assert(expectedt5sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5sendAddress =  Array(0x63.toByte,0xA9.toByte,0x97.toByte,0x5B.toByte,0xA3.toByte,0x1B.toByte,0x0B.toByte,0x96.toByte,0x26.toByte,0xB3.toByte,0x43.toByte,0x00.toByte,0xF7.toByte,0xF6.toByte,0x27.toByte,0x14.toByte,0x7D.toByte,0xF1.toByte,0xF5.toByte,0x26.toByte)
-  assert(expectedt5sendAddress.deep==tsendAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt5hash = Array(0xBB.toByte,0x7C.toByte,0xAA.toByte,0x23.toByte,0x38.toByte,0x5A.toByte,0x0F.toByte,0x73.toByte,0x75.toByte,0x3F.toByte,0x9E.toByte,0x28.toByte,0xD8.toByte,0xF0.toByte,0x60.toByte,0x2F.toByte,0xE2.toByte,0xE7.toByte,0x2D.toByte,0x87.toByte,0xE1.toByte,0xE0.toByte,0x95.toByte,0x52.toByte,0x75.toByte,0x28.toByte,0xD1.toByte,0x44.toByte,0x88.toByte,0x5D.toByte,0x6B.toByte,0x51.toByte)
-  assert(expectedt5hash.deep==thashes(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  transactNum=5
-  val expectedt6Nonce =  Array(0x02.toByte,0xD7.toByte,0xE0.toByte)
-  assert(expectedt6Nonce.deep==tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6Value = 143694920000000000L
-  assert(expectedt6Value==tvalues(transactNum).get(0))
-  val expectedt6ReceiveAddress= Array(0x1F.toByte,0x57.toByte,0xF8.toByte,0x26.toByte,0xCA.toByte,0xF5.toByte,0x94.toByte,0xF7.toByte,0xA8.toByte,0x37.toByte,0xD9.toByte,0xFC.toByte,0x09.toByte,0x24.toByte,0x56.toByte,0x87.toByte,0x0A.toByte,0x28.toByte,0x93.toByte,0x65.toByte)
-    assert(expectedt6ReceiveAddress.deep==treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6GasPrice=20000000000L
-  assert(expectedt6GasPrice==tgasPrices(transactNum).get(0))
-  val expectedt6GasLimit=90000
-  assert(expectedt6GasLimit==tgasLimits(transactNum).get(0))
-  val expectedt6Data : Array[Byte] = Array()
-  assert(expectedt6Data.deep==tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6sigv = Array(0x1C.toByte)
-  assert(expectedt6sigv.deep==tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6sigr = Array(0x0A.toByte,0x4C.toByte,0xA2.toByte,0x18.toByte,0x46.toByte,0x0D.toByte,0xC8.toByte,0x5B.toByte,0x99.toByte,0x07.toByte,0x46.toByte,0xFB.toByte,0xB9.toByte,0x0C.toByte,0x06.toByte,0xF8.toByte,0x25.toByte,0x87.toByte,0x82.toByte,0x80.toByte,0x87.toByte,0x27.toByte,0x98.toByte,0x3C.toByte,0x8B.toByte,0x8D.toByte,0x6A.toByte,0x92.toByte,0x1E.toByte,0x19.toByte,0x9B.toByte,0xCA.toByte)
-   assert(expectedt6sigr.deep==tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6sigs = Array(0x08.toByte,0xA3.toByte,0xB9.toByte,0xA4.toByte,0x5D.toByte,0x83.toByte,0x1A.toByte,0xC4.toByte,0xAD.toByte,0x37.toByte,0x9D.toByte,0x14.toByte,0xF0.toByte,0xAE.toByte,0x3C.toByte,0x03.toByte,0xC8.toByte,0x73.toByte,0x1C.toByte,0xB4.toByte,0x4D.toByte,0x8A.toByte,0x79.toByte,0xAC.toByte,0xD4.toByte,0xCD.toByte,0x6C.toByte,0xEA.toByte,0x1B.toByte,0x54.toByte,0x80.toByte,0x02.toByte)
-  assert(expectedt6sigs.deep==tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6sendAddress =  Array(0x63.toByte,0xA9.toByte,0x97.toByte,0x5B.toByte,0xA3.toByte,0x1B.toByte,0x0B.toByte,0x96.toByte,0x26.toByte,0xB3.toByte,0x43.toByte,0x00.toByte,0xF7.toByte,0xF6.toByte,0x27.toByte,0x14.toByte,0x7D.toByte,0xF1.toByte,0xF5.toByte,0x26.toByte)
-  assert(expectedt6sendAddress.deep==tsendAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  val expectedt6hash = Array(0xBC.toByte,0xDE.toByte,0x6F.toByte,0x49.toByte,0x84.toByte,0x2C.toByte,0x6D.toByte,0x73.toByte,0x8D.toByte,0x64.toByte,0x32.toByte,0x8F.toByte,0x78.toByte,0x09.toByte,0xB1.toByte,0xD4.toByte,0x9B.toByte,0xF0.toByte,0xFF.toByte,0x3F.toByte,0xFA.toByte,0x46.toByte,0x0F.toByte,0xDD.toByte,0xD2.toByte,0x7F.toByte,0xD4.toByte,0x2B.toByte,0x7A.toByte,0x01.toByte,0xFC.toByte,0x9A.toByte)
-  assert(expectedt6hash.deep==thashes(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
-  // uncle headers
+    transactNum = 4
+    val expectedt5Nonce = Array(0x02.toByte, 0xD7.toByte, 0xDF.toByte)
+    assert(expectedt5Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5Value = 144683800000000000L
+    assert(expectedt5Value == tvalues(transactNum).get(0))
+    val expectedt5ReceiveAddress = Array(0x1F.toByte, 0x57.toByte, 0xF8.toByte, 0x26.toByte, 0xCA.toByte, 0xF5.toByte, 0x94.toByte, 0xF7.toByte, 0xA8.toByte, 0x37.toByte, 0xD9.toByte, 0xFC.toByte, 0x09.toByte, 0x24.toByte, 0x56.toByte, 0x87.toByte, 0x0A.toByte, 0x28.toByte, 0x93.toByte, 0x65.toByte)
+    assert(expectedt5ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5GasPrice = 20000000000L
+    assert(expectedt5GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt5GasLimit = 90000
+    assert(expectedt5GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt5Data: Array[Byte] = Array()
+    assert(expectedt5Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5sigv = Array(0x1C.toByte)
+    assert(expectedt5sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5sigr = Array(0xE4.toByte, 0xBE.toByte, 0x97.toByte, 0xD5.toByte, 0xAF.toByte, 0xF1.toByte, 0xB5.toByte, 0xE7.toByte, 0x99.toByte, 0x12.toByte, 0x96.toByte, 0x98.toByte, 0x2B.toByte, 0xDF.toByte, 0xC1.toByte, 0xC2.toByte, 0x2F.toByte, 0x75.toByte, 0x21.toByte, 0x13.toByte, 0x4F.toByte, 0x7E.toByte, 0x1A.toByte, 0x9D.toByte, 0xA3.toByte, 0x00.toByte, 0x42.toByte, 0x0D.toByte, 0xAD.toByte, 0x33.toByte, 0x6F.toByte, 0x34.toByte)
+    assert(expectedt5sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5sigs = Array(0x62.toByte, 0xDE.toByte, 0xF8.toByte, 0xAA.toByte, 0x83.toByte, 0x65.toByte, 0x58.toByte, 0xC7.toByte, 0xB0.toByte, 0xA5.toByte, 0x65.toByte, 0xB9.toByte, 0x7C.toByte, 0x9B.toByte, 0x27.toByte, 0xB2.toByte, 0x0E.toByte, 0xD9.toByte, 0xA0.toByte, 0x51.toByte, 0xDE.toByte, 0x22.toByte, 0xAD.toByte, 0x8D.toByte, 0xBD.toByte, 0x62.toByte, 0x52.toByte, 0x44.toByte, 0xCE.toByte, 0x64.toByte, 0x9E.toByte, 0x3D.toByte)
+    assert(expectedt5sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5sendAddress = Array(0x63.toByte, 0xA9.toByte, 0x97.toByte, 0x5B.toByte, 0xA3.toByte, 0x1B.toByte, 0x0B.toByte, 0x96.toByte, 0x26.toByte, 0xB3.toByte, 0x43.toByte, 0x00.toByte, 0xF7.toByte, 0xF6.toByte, 0x27.toByte, 0x14.toByte, 0x7D.toByte, 0xF1.toByte, 0xF5.toByte, 0x26.toByte)
+    assert(expectedt5sendAddress.deep == tsendAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt5hash = Array(0xBB.toByte, 0x7C.toByte, 0xAA.toByte, 0x23.toByte, 0x38.toByte, 0x5A.toByte, 0x0F.toByte, 0x73.toByte, 0x75.toByte, 0x3F.toByte, 0x9E.toByte, 0x28.toByte, 0xD8.toByte, 0xF0.toByte, 0x60.toByte, 0x2F.toByte, 0xE2.toByte, 0xE7.toByte, 0x2D.toByte, 0x87.toByte, 0xE1.toByte, 0xE0.toByte, 0x95.toByte, 0x52.toByte, 0x75.toByte, 0x28.toByte, 0xD1.toByte, 0x44.toByte, 0x88.toByte, 0x5D.toByte, 0x6B.toByte, 0x51.toByte)
+    assert(expectedt5hash.deep == thashes(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    transactNum = 5
+    val expectedt6Nonce = Array(0x02.toByte, 0xD7.toByte, 0xE0.toByte)
+    assert(expectedt6Nonce.deep == tnonces(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6Value = 143694920000000000L
+    assert(expectedt6Value == tvalues(transactNum).get(0))
+    val expectedt6ReceiveAddress = Array(0x1F.toByte, 0x57.toByte, 0xF8.toByte, 0x26.toByte, 0xCA.toByte, 0xF5.toByte, 0x94.toByte, 0xF7.toByte, 0xA8.toByte, 0x37.toByte, 0xD9.toByte, 0xFC.toByte, 0x09.toByte, 0x24.toByte, 0x56.toByte, 0x87.toByte, 0x0A.toByte, 0x28.toByte, 0x93.toByte, 0x65.toByte)
+    assert(expectedt6ReceiveAddress.deep == treceiveAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6GasPrice = 20000000000L
+    assert(expectedt6GasPrice == tgasPrices(transactNum).get(0))
+    val expectedt6GasLimit = 90000
+    assert(expectedt6GasLimit == tgasLimits(transactNum).get(0))
+    val expectedt6Data: Array[Byte] = Array()
+    assert(expectedt6Data.deep == tdatas(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6sigv = Array(0x1C.toByte)
+    assert(expectedt6sigv.deep == tsigvs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6sigr = Array(0x0A.toByte, 0x4C.toByte, 0xA2.toByte, 0x18.toByte, 0x46.toByte, 0x0D.toByte, 0xC8.toByte, 0x5B.toByte, 0x99.toByte, 0x07.toByte, 0x46.toByte, 0xFB.toByte, 0xB9.toByte, 0x0C.toByte, 0x06.toByte, 0xF8.toByte, 0x25.toByte, 0x87.toByte, 0x82.toByte, 0x80.toByte, 0x87.toByte, 0x27.toByte, 0x98.toByte, 0x3C.toByte, 0x8B.toByte, 0x8D.toByte, 0x6A.toByte, 0x92.toByte, 0x1E.toByte, 0x19.toByte, 0x9B.toByte, 0xCA.toByte)
+    assert(expectedt6sigr.deep == tsigrs(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6sigs = Array(0x08.toByte, 0xA3.toByte, 0xB9.toByte, 0xA4.toByte, 0x5D.toByte, 0x83.toByte, 0x1A.toByte, 0xC4.toByte, 0xAD.toByte, 0x37.toByte, 0x9D.toByte, 0x14.toByte, 0xF0.toByte, 0xAE.toByte, 0x3C.toByte, 0x03.toByte, 0xC8.toByte, 0x73.toByte, 0x1C.toByte, 0xB4.toByte, 0x4D.toByte, 0x8A.toByte, 0x79.toByte, 0xAC.toByte, 0xD4.toByte, 0xCD.toByte, 0x6C.toByte, 0xEA.toByte, 0x1B.toByte, 0x54.toByte, 0x80.toByte, 0x02.toByte)
+    assert(expectedt6sigs.deep == tsigss(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6sendAddress = Array(0x63.toByte, 0xA9.toByte, 0x97.toByte, 0x5B.toByte, 0xA3.toByte, 0x1B.toByte, 0x0B.toByte, 0x96.toByte, 0x26.toByte, 0xB3.toByte, 0x43.toByte, 0x00.toByte, 0xF7.toByte, 0xF6.toByte, 0x27.toByte, 0x14.toByte, 0x7D.toByte, 0xF1.toByte, 0xF5.toByte, 0x26.toByte)
+    assert(expectedt6sendAddress.deep == tsendAddresses(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    val expectedt6hash = Array(0xBC.toByte, 0xDE.toByte, 0x6F.toByte, 0x49.toByte, 0x84.toByte, 0x2C.toByte, 0x6D.toByte, 0x73.toByte, 0x8D.toByte, 0x64.toByte, 0x32.toByte, 0x8F.toByte, 0x78.toByte, 0x09.toByte, 0xB1.toByte, 0xD4.toByte, 0x9B.toByte, 0xF0.toByte, 0xFF.toByte, 0x3F.toByte, 0xFA.toByte, 0x46.toByte, 0x0F.toByte, 0xDD.toByte, 0xD2.toByte, 0x7F.toByte, 0xD4.toByte, 0x2B.toByte, 0x7A.toByte, 0x01.toByte, 0xFC.toByte, 0x9A.toByte)
+    assert(expectedt6hash.deep == thashes(transactNum).get(0).asInstanceOf[Array[Byte]].deep)
+    // uncle headers
     // block does not contain uncleheaders
 
-  import df.sparkSession.implicits._
+
+import df.sparkSession.implicits._
 
   df.as[EnrichedEthereumBlock].collect()
 
 }
-
 
 
 }

--- a/src/main/scala/org/zuinnote/spark/bitcoin/block/BitcoinBlockRelation.scala
+++ b/src/main/scala/org/zuinnote/spark/bitcoin/block/BitcoinBlockRelation.scala
@@ -1,490 +1,602 @@
 /**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+  * Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 package org.zuinnote.spark.bitcoin.block
 
-import scala.collection.JavaConversions._
-
-
-import org.apache.spark.sql.sources.{BaseRelation,TableScan}
-import org.apache.spark.sql.types.DataType
-import org.apache.spark.sql.types.ArrayType
-import org.apache.spark.sql.types.ByteType
-import org.apache.spark.sql.types.BinaryType
-import org.apache.spark.sql.types.IntegerType
-import org.apache.spark.sql.types.LongType
-import org.apache.spark.sql.types.StructField
-import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.SQLContext
-
-import org.apache.spark.sql._
-import org.apache.spark.rdd.RDD
-
-import org.apache.hadoop.conf._
-import org.apache.hadoop.mapred._
-
-
-
 import org.apache.commons.logging.LogFactory
-import org.apache.commons.logging.Log
-
-
+import org.apache.hadoop.conf._
+import org.apache.hadoop.io.BytesWritable
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.sources.{BaseRelation, TableScan}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{SQLContext, _}
 import org.zuinnote.hadoop.bitcoin.format.common._
 import org.zuinnote.hadoop.bitcoin.format.mapreduce._
 import org.zuinnote.spark.bitcoin.util.BitcoinBlockFile
 
-/**
-* Author: Jörn Franke <zuinnote@gmail.com>
-*
-*/
+import scala.collection.JavaConversions._
 
 /**
-* Defines the schema of a BitcoinBlock for Spark SQL
-*
-*/
+  * Author: Jörn Franke <zuinnote@gmail.com>
+  *
+  * Defines the schema of a BitcoinBlock for Spark SQL
+  */
+case class BitcoinBlockRelation(location: String,
+                                maxBlockSize: Integer = AbstractBitcoinRecordReader.DEFAULT_MAXSIZE_BITCOINBLOCK,
+                                magic: String = AbstractBitcoinRecordReader.DEFAULT_MAGIC,
+                                useDirectBuffer: Boolean = AbstractBitcoinRecordReader.DEFAULT_USEDIRECTBUFFER,
+                                isSplittable: Boolean = AbstractBitcoinFileInputFormat.DEFAULT_ISSPLITABLE,
+                                readAuxPOW: Boolean = AbstractBitcoinRecordReader.DEFAULT_READAUXPOW,
+                                enrich: Boolean = false)(@transient val sqlContext: SQLContext)
+  extends BaseRelation with TableScan with Serializable {
 
-case class BitcoinBlockRelation(location: String,maxBlockSize: Integer = AbstractBitcoinRecordReader.DEFAULT_MAXSIZE_BITCOINBLOCK,magic: String = AbstractBitcoinRecordReader.DEFAULT_MAGIC,useDirectBuffer: Boolean = AbstractBitcoinRecordReader.DEFAULT_USEDIRECTBUFFER,isSplitable: Boolean = AbstractBitcoinFileInputFormat.DEFAULT_ISSPLITABLE,readAuxPOW: Boolean = AbstractBitcoinRecordReader.DEFAULT_READAUXPOW, enrich: Boolean = false)
-(@transient val sqlContext: SQLContext)
-  extends BaseRelation with TableScan
-       with Serializable {
-  val LOG = LogFactory.getLog(BitcoinBlockRelation.getClass);
+  private lazy val LOG = LogFactory.getLog(BitcoinBlockRelation.getClass)
 
   override def schema: StructType = {
-    val structNoAuxPow = StructType(Seq(StructField("blockSize", IntegerType, false),
-                          StructField("magicNo", BinaryType, false),
-      StructField("version", IntegerType, false),
-      StructField("time", IntegerType, false),
-      StructField("bits", BinaryType, false),
-      StructField("nonce", IntegerType, false),
-      StructField("transactionCounter", LongType, false),
-      StructField("hashPrevBlock", BinaryType, false),
-      StructField("hashMerkleRoot", BinaryType, false),
-      StructField("transactions",ArrayType(StructType(Seq
-        (StructField("version", IntegerType, false),
-        StructField("marker", ByteType, false),
-        StructField("flag", ByteType, false),
-        StructField("inCounter",BinaryType, false),
-        StructField("outCounter", BinaryType, false),
-        StructField("listOfInputs",ArrayType(StructType(Seq(
-          StructField("prevTransactionHash",BinaryType,false),
-          StructField("previousTxOutIndex",LongType,false),
-          StructField("txInScriptLength",BinaryType,false),
-          StructField("txInScript",BinaryType,false),
-          StructField("seqNo",LongType,false)))), false),
-        StructField("listOfOutputs",ArrayType(StructType(Seq(
-          StructField("value",LongType,false),
-          StructField("txOutScriptLength",BinaryType,false),
-          StructField("txOutScript",BinaryType,false)))), false),
-          StructField("listOfScriptWitnessItem",ArrayType(StructType(Seq(
-                StructField("stackItemCounter",BinaryType,false),
-                StructField("scriptWitnessList",ArrayType(StructType(Seq(
-                  StructField("witnessScriptLength",BinaryType,false),
-                  StructField("witnessScript",BinaryType,false)
-                )), false)
-                ))), false)),
-            StructField("lockTime", IntegerType, false)))
-    ))))
+    val structNoAuxPow = StructType(
+      Seq(
+        StructField("blockSize", IntegerType, nullable = false),
+        StructField("magicNo", BinaryType, nullable = false),
+        StructField("version", IntegerType, nullable = false),
+        StructField("time", IntegerType, nullable = false),
+        StructField("bits", BinaryType, nullable = false),
+        StructField("nonce", IntegerType, nullable = false),
+        StructField("transactionCounter", LongType, nullable = false),
+        StructField("hashPrevBlock", BinaryType, nullable = false),
+        StructField("hashMerkleRoot", BinaryType, nullable = false),
+        StructField(
+          "transactions",
+          ArrayType(StructType(Seq(
+            StructField("version", IntegerType, nullable = false),
+            StructField("marker", ByteType, nullable = false),
+            StructField("flag", ByteType, nullable = false),
+            StructField("inCounter", BinaryType, nullable = false),
+            StructField("outCounter", BinaryType, nullable = false),
+            StructField(
+              "listOfInputs",
+              ArrayType(StructType(Seq(
+                StructField("prevTransactionHash", BinaryType, nullable = false),
+                StructField("previousTxOutIndex", LongType, nullable = false),
+                StructField("txInScriptLength", BinaryType, nullable = false),
+                StructField("txInScript", BinaryType, nullable = false),
+                StructField("seqNo", LongType, nullable = false)
+              ))),
+              nullable = false
+            ),
+            StructField(
+              "listOfOutputs",
+              ArrayType(StructType(Seq(StructField("value", LongType, nullable = false),
+                StructField("txOutScriptLength", BinaryType, nullable = false),
+                StructField("txOutScript", BinaryType, nullable = false)))),
+              nullable = false
+            ),
+            StructField(
+              "listOfScriptWitnessItem",
+              ArrayType(
+                StructType(Seq(
+                  StructField("stackItemCounter", BinaryType, nullable = false),
+                  StructField(
+                    "scriptWitnessList",
+                    ArrayType(StructType(Seq(
+                      StructField("witnessScriptLength", BinaryType, nullable = false),
+                      StructField("witnessScript", BinaryType, nullable = false)
+                    )),
+                      containsNull = false)
+                  )
+                )),
+                containsNull = false
+              )
+            ),
+            StructField("lockTime", IntegerType, nullable = false)
+          )))
+        )
+      ))
 
-    val structNoAuxPowEnrich = StructType(Seq(StructField("blockSize", IntegerType, false),
-                          StructField("magicNo", BinaryType, false),
-      StructField("version", IntegerType, false),
-      StructField("time", IntegerType, false),
-      StructField("bits", BinaryType, false),
-      StructField("nonce", IntegerType, false),
-      StructField("transactionCounter", LongType, false),
-      StructField("hashPrevBlock", BinaryType, false),
-      StructField("hashMerkleRoot", BinaryType, false),
-      StructField("transactions",ArrayType(StructType(Seq
-        (StructField("version", IntegerType, false),
-        StructField("marker", ByteType, false),
-        StructField("flag", ByteType, false),
-        StructField("inCounter",BinaryType, false),
-        StructField("outCounter", BinaryType, false),
-        StructField("listOfInputs",ArrayType(StructType(Seq(
-          StructField("prevTransactionHash",BinaryType,false),
-          StructField("previousTxOutIndex",LongType,false),
-          StructField("txInScriptLength",BinaryType,false),
-          StructField("txInScript",BinaryType,false),
-          StructField("seqNo",LongType,false)))), false),
-        StructField("listOfOutputs",ArrayType(StructType(Seq(
-          StructField("value",LongType,false),
-          StructField("txOutScriptLength",BinaryType,false),
-          StructField("txOutScript",BinaryType,false)))), false),
-          StructField("listOfScriptWitnessItem",ArrayType(StructType(Seq(
-                StructField("stackItemCounter",BinaryType,false),
-                StructField("scriptWitnessList",ArrayType(StructType(Seq(
-                  StructField("witnessScriptLength",BinaryType,false),
-                  StructField("witnessScript",BinaryType,false)
-                )), false)
-                ))), false)),
-            StructField("lockTime", IntegerType, false),
-            StructField("currentTransactionHash", BinaryType, false)))
-    ))))
+    val structNoAuxPowEnrich = StructType(
+      Seq(
+        StructField("blockSize", IntegerType, nullable = false),
+        StructField("magicNo", BinaryType, nullable = false),
+        StructField("version", IntegerType, nullable = false),
+        StructField("time", IntegerType, nullable = false),
+        StructField("bits", BinaryType, nullable = false),
+        StructField("nonce", IntegerType, nullable = false),
+        StructField("transactionCounter", LongType, nullable = false),
+        StructField("hashPrevBlock", BinaryType, nullable = false),
+        StructField("hashMerkleRoot", BinaryType, nullable = false),
+        StructField(
+          "transactions",
+          ArrayType(StructType(Seq(
+            StructField("version", IntegerType, nullable = false),
+            StructField("marker", ByteType, nullable = false),
+            StructField("flag", ByteType, nullable = false),
+            StructField("inCounter", BinaryType, nullable = false),
+            StructField("outCounter", BinaryType, nullable = false),
+            StructField(
+              "listOfInputs",
+              ArrayType(StructType(Seq(
+                StructField("prevTransactionHash", BinaryType, nullable = false),
+                StructField("previousTxOutIndex", LongType, nullable = false),
+                StructField("txInScriptLength", BinaryType, nullable = false),
+                StructField("txInScript", BinaryType, nullable = false),
+                StructField("seqNo", LongType, nullable = false)
+              ))),
+              nullable = false
+            ),
+            StructField(
+              "listOfOutputs",
+              ArrayType(StructType(Seq(StructField("value", LongType, nullable = false),
+                StructField("txOutScriptLength", BinaryType, nullable = false),
+                StructField("txOutScript", BinaryType, nullable = false)))),
+              nullable = false
+            ),
+            StructField(
+              "listOfScriptWitnessItem",
+              ArrayType(
+                StructType(Seq(
+                  StructField("stackItemCounter", BinaryType, nullable = false),
+                  StructField(
+                    "scriptWitnessList",
+                    ArrayType(StructType(Seq(
+                      StructField("witnessScriptLength", BinaryType, nullable = false),
+                      StructField("witnessScript", BinaryType, nullable = false)
+                    )),
+                      containsNull = false)
+                  )
+                )),
+                containsNull = false
+              )
+            ),
+            StructField("lockTime", IntegerType, nullable = false),
+            StructField("currentTransactionHash", BinaryType, nullable = false)
+          )))
+        )
+      ))
 
-    val structAuxPow = StructType(Seq(StructField("blockSize", IntegerType, false),
-                          StructField("magicNo", BinaryType, false),
-      StructField("version", IntegerType, false),
-      StructField("time", IntegerType, false),
-      StructField("bits", BinaryType, false),
-      StructField("nonce", IntegerType, false),
-      StructField("transactionCounter", LongType, false),
-      StructField("hashPrevBlock", BinaryType, false),
-      StructField("hashMerkleRoot", BinaryType, false),
-      StructField("transactions",ArrayType(StructType(Seq
-        (StructField("version", IntegerType, false),
-        StructField("marker", ByteType, false),
-        StructField("flag", ByteType, false),
-        StructField("inCounter",BinaryType, false),
-        StructField("outCounter", BinaryType, false),
-        StructField("listOfInputs",ArrayType(StructType(Seq(
-          StructField("prevTransactionHash",BinaryType,false),
-          StructField("previousTxOutIndex",LongType,false),
-          StructField("txInScriptLength",BinaryType,false),
-          StructField("txInScript",BinaryType,false),
-          StructField("seqNo",LongType,false)))), false),
-        StructField("listOfOutputs",ArrayType(StructType(Seq(
-          StructField("value",LongType,false),
-          StructField("txOutScriptLength",BinaryType,false),
-          StructField("txOutScript",BinaryType,false)))), false),
-          StructField("listOfScriptWitnessItem",ArrayType(StructType(Seq(
-                StructField("stackItemCounter",BinaryType,false),
-                StructField("scriptWitnessList",ArrayType(StructType(Seq(
-                  StructField("witnessScriptLength",BinaryType,false),
-                  StructField("witnessScript",BinaryType,false)
-                )), false)
-                ))), false)),
-            StructField("lockTime", IntegerType, false)))
-    )),
-      StructField("auxPOW",StructType(Seq(
-            StructField("version", IntegerType, false),
-            StructField("coinbaseTransaction",StructType(Seq
-              (StructField("version", IntegerType, false),
-              StructField("inCounter",BinaryType, false),
-              StructField("outCounter", BinaryType, false),
-              StructField("listOfInputs",ArrayType(StructType(Seq(
-                StructField("prevTransactionHash",BinaryType,false),
-                StructField("previousTxOutIndex",LongType,false),
-                StructField("txInScriptLength",BinaryType,false),
-                StructField("txInScript",BinaryType,false),
-                StructField("seqNo",LongType,false)))), false),
-              StructField("listOfOutputs",ArrayType(StructType(Seq(
-                StructField("value",LongType,false),
-                StructField("txOutScriptLength",BinaryType,false),
-                StructField("txOutScript",BinaryType,false)))), false),
-              StructField("lockTime", IntegerType, false))), false),
-            StructField("parentBlockHeaderHash", BinaryType, false),
-            StructField("coinbaseBranch", StructType(Seq(
-                  StructField("numberOfLinks", BinaryType, false),
-                  StructField("links", ArrayType(BinaryType), false),
-                  StructField("branchSideBitmask", BinaryType, false)
-            )), false),
-            StructField("auxBlockChainBranch", StructType(Seq(
-                  StructField("numberOfLinks", BinaryType, false),
-                  StructField("links", ArrayType(BinaryType), false),
-                  StructField("branchSideBitmask", BinaryType, false)
-            )), false),
-            StructField("parentBlockHeader",StructType(Seq(
-              StructField("version", IntegerType, false),
-              StructField("previousBlockHash", BinaryType, false),
-              StructField("merkleRoot",BinaryType, false),
-              StructField("time", IntegerType, false),
-              StructField("bits", BinaryType, false),
-              StructField("nonce", IntegerType, false)
-            )), false))))))
+    val structAuxPow = StructType(
+      Seq(
+        StructField("blockSize", IntegerType, nullable = false),
+        StructField("magicNo", BinaryType, nullable = false),
+        StructField("version", IntegerType, nullable = false),
+        StructField("time", IntegerType, nullable = false),
+        StructField("bits", BinaryType, nullable = false),
+        StructField("nonce", IntegerType, nullable = false),
+        StructField("transactionCounter", LongType, nullable = false),
+        StructField("hashPrevBlock", BinaryType, nullable = false),
+        StructField("hashMerkleRoot", BinaryType, nullable = false),
+        StructField(
+          "transactions",
+          ArrayType(StructType(Seq(
+            StructField("version", IntegerType, nullable = false),
+            StructField("marker", ByteType, nullable = false),
+            StructField("flag", ByteType, nullable = false),
+            StructField("inCounter", BinaryType, nullable = false),
+            StructField("outCounter", BinaryType, nullable = false),
+            StructField(
+              "listOfInputs",
+              ArrayType(StructType(Seq(
+                StructField("prevTransactionHash", BinaryType, nullable = false),
+                StructField("previousTxOutIndex", LongType, nullable = false),
+                StructField("txInScriptLength", BinaryType, nullable = false),
+                StructField("txInScript", BinaryType, nullable = false),
+                StructField("seqNo", LongType, nullable = false)
+              ))),
+              nullable = false
+            ),
+            StructField(
+              "listOfOutputs",
+              ArrayType(StructType(Seq(StructField("value", LongType, nullable = false),
+                StructField("txOutScriptLength", BinaryType, nullable = false),
+                StructField("txOutScript", BinaryType, nullable = false)))),
+              nullable = false
+            ),
+            StructField(
+              "listOfScriptWitnessItem",
+              ArrayType(
+                StructType(Seq(
+                  StructField("stackItemCounter", BinaryType, nullable = false),
+                  StructField(
+                    "scriptWitnessList",
+                    ArrayType(StructType(Seq(
+                      StructField("witnessScriptLength", BinaryType, nullable = false),
+                      StructField("witnessScript", BinaryType, nullable = false)
+                    )),
+                      containsNull = false)
+                  )
+                )),
+                containsNull = false
+              )
+            ),
+            StructField("lockTime", IntegerType, nullable = false)
+          )))
+        ),
+        StructField(
+          "auxPOW",
+          StructType(Seq(
+            StructField("version", IntegerType, nullable = false),
+            StructField(
+              "coinbaseTransaction",
+              StructType(Seq(
+                StructField("version", IntegerType, nullable = false),
+                StructField("inCounter", BinaryType, nullable = false),
+                StructField("outCounter", BinaryType, nullable = false),
+                StructField(
+                  "listOfInputs",
+                  ArrayType(StructType(Seq(
+                    StructField("prevTransactionHash", BinaryType, nullable = false),
+                    StructField("previousTxOutIndex", LongType, nullable = false),
+                    StructField("txInScriptLength", BinaryType, nullable = false),
+                    StructField("txInScript", BinaryType, nullable = false),
+                    StructField("seqNo", LongType, nullable = false)
+                  ))),
+                  nullable = false
+                ),
+                StructField(
+                  "listOfOutputs",
+                  ArrayType(StructType(Seq(StructField("value", LongType, nullable = false),
+                    StructField("txOutScriptLength", BinaryType, nullable = false),
+                    StructField("txOutScript", BinaryType, nullable = false)))),
+                  nullable = false
+                ),
+                StructField("lockTime", IntegerType, nullable = false)
+              )),
+              nullable = false
+            ),
+            StructField("parentBlockHeaderHash", BinaryType, nullable = false),
+            StructField(
+              "coinbaseBranch",
+              StructType(
+                Seq(
+                  StructField("numberOfLinks", BinaryType, nullable = false),
+                  StructField("links", ArrayType(BinaryType), nullable = false),
+                  StructField("branchSideBitmask", BinaryType, nullable = false)
+                )),
+              nullable = false
+            ),
+            StructField(
+              "auxBlockChainBranch",
+              StructType(
+                Seq(
+                  StructField("numberOfLinks", BinaryType, nullable = false),
+                  StructField("links", ArrayType(BinaryType), nullable = false),
+                  StructField("branchSideBitmask", BinaryType, nullable = false)
+                )),
+              nullable = false
+            ),
+            StructField(
+              "parentBlockHeader",
+              StructType(Seq(
+                StructField("version", IntegerType, nullable = false),
+                StructField("previousBlockHash", BinaryType, nullable = false),
+                StructField("merkleRoot", BinaryType, nullable = false),
+                StructField("time", IntegerType, nullable = false),
+                StructField("bits", BinaryType, nullable = false),
+                StructField("nonce", IntegerType, nullable = false)
+              )),
+              nullable = false
+            )
+          ))
+        )
+      ))
 
-            val structAuxPowEnrich = StructType(Seq(StructField("blockSize", IntegerType, false),
-                                  StructField("magicNo", BinaryType, false),
-              StructField("version", IntegerType, false),
-              StructField("time", IntegerType, false),
-              StructField("bits", BinaryType, false),
-              StructField("nonce", IntegerType, false),
-              StructField("transactionCounter", LongType, false),
-              StructField("hashPrevBlock", BinaryType, false),
-              StructField("hashMerkleRoot", BinaryType, false),
-              StructField("transactions",ArrayType(StructType(Seq
-                (StructField("version", IntegerType, false),
-                StructField("marker", ByteType, false),
-                StructField("flag", ByteType, false),
-                StructField("inCounter",BinaryType, false),
-                StructField("outCounter", BinaryType, false),
-                StructField("listOfInputs",ArrayType(StructType(Seq(
-                  StructField("prevTransactionHash",BinaryType,false),
-                  StructField("previousTxOutIndex",LongType,false),
-                  StructField("txInScriptLength",BinaryType,false),
-                  StructField("txInScript",BinaryType,false),
-                  StructField("seqNo",LongType,false)))), false),
-                StructField("listOfOutputs",ArrayType(StructType(Seq(
-                  StructField("value",LongType,false),
-                  StructField("txOutScriptLength",BinaryType,false),
-                  StructField("txOutScript",BinaryType,false)))), false),
-                  StructField("listOfScriptWitnessItem",ArrayType(StructType(Seq(
-                        StructField("stackItemCounter",BinaryType,false),
-                        StructField("scriptWitnessList",ArrayType(StructType(Seq(
-                          StructField("witnessScriptLength",BinaryType,false),
-                          StructField("witnessScript",BinaryType,false)
-                        )), false)
-                        ))), false)),
-                    StructField("lockTime", IntegerType, false),
-                    StructField("currentTransactionHash", BinaryType, false)))
-            )),
-              StructField("auxPOW",StructType(Seq(
-                    StructField("version", IntegerType, false),
-                    StructField("coinbaseTransaction",StructType(Seq
-                      (StructField("version", IntegerType, false),
-                      StructField("inCounter",BinaryType, false),
-                      StructField("outCounter", BinaryType, false),
-                      StructField("listOfInputs",ArrayType(StructType(Seq(
-                        StructField("prevTransactionHash",BinaryType,false),
-                        StructField("previousTxOutIndex",LongType,false),
-                        StructField("txInScriptLength",BinaryType,false),
-                        StructField("txInScript",BinaryType,false),
-                        StructField("seqNo",LongType,false)))), false),
-                      StructField("listOfOutputs",ArrayType(StructType(Seq(
-                        StructField("value",LongType,false),
-                        StructField("txOutScriptLength",BinaryType,false),
-                        StructField("txOutScript",BinaryType,false)))), false),
-                      StructField("lockTime", IntegerType, false))), false),
-                    StructField("parentBlockHeaderHash", BinaryType, false),
-                    StructField("coinbaseBranch", StructType(Seq(
-                          StructField("numberOfLinks", BinaryType, false),
-                          StructField("links", ArrayType(BinaryType), false),
-                          StructField("branchSideBitmask", BinaryType, false)
-                    )), false),
-                    StructField("auxBlockChainBranch", StructType(Seq(
-                          StructField("numberOfLinks", BinaryType, false),
-                          StructField("links", ArrayType(BinaryType), false),
-                          StructField("branchSideBitmask", BinaryType, false)
-                    )), false),
-                    StructField("parentBlockHeader",StructType(Seq(
-                      StructField("version", IntegerType, false),
-                      StructField("previousBlockHash", BinaryType, false),
-                      StructField("merkleRoot",BinaryType, false),
-                      StructField("time", IntegerType, false),
-                      StructField("bits", BinaryType, false),
-                      StructField("nonce", IntegerType, false)
-                    )), false))))))
-      if (readAuxPOW) {
-       if (enrich) {
-          return structAuxPowEnrich
-       } else {
-       return structAuxPow
-       }
-      }
+    val structAuxPowEnrich = StructType(
+      Seq(
+        StructField("blockSize", IntegerType, nullable = false),
+        StructField("magicNo", BinaryType, nullable = false),
+        StructField("version", IntegerType, nullable = false),
+        StructField("time", IntegerType, nullable = false),
+        StructField("bits", BinaryType, nullable = false),
+        StructField("nonce", IntegerType, nullable = false),
+        StructField("transactionCounter", LongType, nullable = false),
+        StructField("hashPrevBlock", BinaryType, nullable = false),
+        StructField("hashMerkleRoot", BinaryType, nullable = false),
+        StructField(
+          "transactions",
+          ArrayType(StructType(Seq(
+            StructField("version", IntegerType, nullable = false),
+            StructField("marker", ByteType, nullable = false),
+            StructField("flag", ByteType, nullable = false),
+            StructField("inCounter", BinaryType, nullable = false),
+            StructField("outCounter", BinaryType, nullable = false),
+            StructField(
+              "listOfInputs",
+              ArrayType(StructType(Seq(
+                StructField("prevTransactionHash", BinaryType, nullable = false),
+                StructField("previousTxOutIndex", LongType, nullable = false),
+                StructField("txInScriptLength", BinaryType, nullable = false),
+                StructField("txInScript", BinaryType, nullable = false),
+                StructField("seqNo", LongType, nullable = false)
+              ))),
+              nullable = false
+            ),
+            StructField(
+              "listOfOutputs",
+              ArrayType(StructType(Seq(StructField("value", LongType, nullable = false),
+                StructField("txOutScriptLength", BinaryType, nullable = false),
+                StructField("txOutScript", BinaryType, nullable = false)))),
+              nullable = false
+            ),
+            StructField(
+              "listOfScriptWitnessItem",
+              ArrayType(
+                StructType(Seq(
+                  StructField("stackItemCounter", BinaryType, nullable = false),
+                  StructField(
+                    "scriptWitnessList",
+                    ArrayType(StructType(Seq(
+                      StructField("witnessScriptLength", BinaryType, nullable = false),
+                      StructField("witnessScript", BinaryType, nullable = false)
+                    )),
+                      containsNull = false)
+                  )
+                )),
+                containsNull = false
+              )
+            ),
+            StructField("lockTime", IntegerType, nullable = false),
+            StructField("currentTransactionHash", BinaryType, nullable = false)
+          )))
+        ),
+        StructField(
+          "auxPOW",
+          StructType(Seq(
+            StructField("version", IntegerType, nullable = false),
+            StructField(
+              "coinbaseTransaction",
+              StructType(Seq(
+                StructField("version", IntegerType, nullable = false),
+                StructField("inCounter", BinaryType, nullable = false),
+                StructField("outCounter", BinaryType, nullable = false),
+                StructField(
+                  "listOfInputs",
+                  ArrayType(StructType(Seq(
+                    StructField("prevTransactionHash", BinaryType, nullable = false),
+                    StructField("previousTxOutIndex", LongType, nullable = false),
+                    StructField("txInScriptLength", BinaryType, nullable = false),
+                    StructField("txInScript", BinaryType, nullable = false),
+                    StructField("seqNo", LongType, nullable = false)
+                  ))),
+                  nullable = false
+                ),
+                StructField(
+                  "listOfOutputs",
+                  ArrayType(StructType(Seq(StructField("value", LongType, nullable = false),
+                    StructField("txOutScriptLength", BinaryType, nullable = false),
+                    StructField("txOutScript", BinaryType, nullable = false)))),
+                  nullable = false
+                ),
+                StructField("lockTime", IntegerType, nullable = false)
+              )),
+              nullable = false
+            ),
+            StructField("parentBlockHeaderHash", BinaryType, nullable = false),
+            StructField(
+              "coinbaseBranch",
+              StructType(
+                Seq(
+                  StructField("numberOfLinks", BinaryType, nullable = false),
+                  StructField("links", ArrayType(BinaryType), nullable = false),
+                  StructField("branchSideBitmask", BinaryType, nullable = false)
+                )),
+              nullable = false
+            ),
+            StructField(
+              "auxBlockChainBranch",
+              StructType(
+                Seq(
+                  StructField("numberOfLinks", BinaryType, nullable = false),
+                  StructField("links", ArrayType(BinaryType), nullable = false),
+                  StructField("branchSideBitmask", BinaryType, nullable = false)
+                )),
+              nullable = false
+            ),
+            StructField(
+              "parentBlockHeader",
+              StructType(Seq(
+                StructField("version", IntegerType, nullable = false),
+                StructField("previousBlockHash", BinaryType, nullable = false),
+                StructField("merkleRoot", BinaryType, nullable = false),
+                StructField("time", IntegerType, nullable = false),
+                StructField("bits", BinaryType, nullable = false),
+                StructField("nonce", IntegerType, nullable = false)
+              )),
+              nullable = false
+            )
+          ))
+        )
+      ))
+
+    if (readAuxPOW) {
       if (enrich) {
-        return structNoAuxPowEnrich
+        structAuxPowEnrich
+      } else {
+        structAuxPow
       }
-      return structNoAuxPow
+    } else {
+      if (enrich) {
+        structNoAuxPowEnrich
+      } else {
+        structNoAuxPow
+      }
     }
+  }
 
-
-
-    /**
-     * Used by Spark to fetch Bitcoin blocks according to the schema specified above from files.
-     *
-     *
-     * returns BitcoinBlocks as rows
+  /**
+    * Used by Spark to fetch Bitcoin blocks according to the schema specified above from files.
+    *
+    *
+    * returns BitcoinBlocks as rows
     **/
-    override def buildScan: RDD[Row] = {
-	// create hadoopConf
-	val hadoopConf = new Configuration()
- 	hadoopConf.set(AbstractBitcoinRecordReader.CONF_MAXBLOCKSIZE,String.valueOf(maxBlockSize))
- 	hadoopConf.set(AbstractBitcoinRecordReader.CONF_FILTERMAGIC,magic)
- 	hadoopConf.set(AbstractBitcoinRecordReader.CONF_USEDIRECTBUFFER,String.valueOf(useDirectBuffer))
- 	hadoopConf.set(AbstractBitcoinFileInputFormat.CONF_ISSPLITABLE, String.valueOf(isSplitable))
-  hadoopConf.set(AbstractBitcoinRecordReader.CONF_READAUXPOW,String.valueOf(readAuxPOW))
-        // read BitcoinBlock
-	val bitcoinBlockRDD = BitcoinBlockFile.load(sqlContext, location, hadoopConf)
-        // map to schema
-	val schemaFields = schema.fields
-	val rowArray = new Array[Any](schemaFields.length)
-        bitcoinBlockRDD.flatMap(hadoopKeyValueTuple => {
-		// map the BitcoinBlock data structure to a Spark SQL schema
-		rowArray(0) = hadoopKeyValueTuple._2.getBlockSize
-		rowArray(1) = hadoopKeyValueTuple._2.getMagicNo
-		rowArray(2) = hadoopKeyValueTuple._2.getVersion
-		rowArray(3) = hadoopKeyValueTuple._2.getTime
-		rowArray(4) = hadoopKeyValueTuple._2.getBits
-		rowArray(5) = hadoopKeyValueTuple._2.getNonce
-		rowArray(6) = hadoopKeyValueTuple._2.getTransactionCounter
-		rowArray(7) = hadoopKeyValueTuple._2.getHashPrevBlock
-		rowArray(8) = hadoopKeyValueTuple._2.getHashMerkleRoot
-		// map transactions
-		var transactionArray=new Array[Any](hadoopKeyValueTuple._2.getTransactions().size())
-		var i=0
-		for (currentTransaction <- hadoopKeyValueTuple._2.getTransactions()) {
-      var aSize = 9
-      if (enrich) {
-          aSize=10
-      }
-			val currentTransactionStructArray = new Array[Any](aSize)
-			currentTransactionStructArray(0)=currentTransaction.getVersion
-      currentTransactionStructArray(1)=currentTransaction.getMarker
-      currentTransactionStructArray(2)=currentTransaction.getFlag
-			currentTransactionStructArray(3)=currentTransaction.getInCounter
-			currentTransactionStructArray(4)=currentTransaction.getOutCounter
-			val currentTransactionListOfInputs = new Array[Any](currentTransaction.getListOfInputs().size())
-			// map inputs
-			var j=0
-			for (currentTransactionInput <-currentTransaction.getListOfInputs) {
-				val currentTransactionInputStructArray = new Array[Any](5)
-				currentTransactionInputStructArray(0)=currentTransactionInput.getPrevTransactionHash
-				currentTransactionInputStructArray(1)=currentTransactionInput.getPreviousTxOutIndex
-				currentTransactionInputStructArray(2)=currentTransactionInput.getTxInScriptLength
-				currentTransactionInputStructArray(3)=currentTransactionInput.getTxInScript
-				currentTransactionInputStructArray(4)=currentTransactionInput.getSeqNo
-				currentTransactionListOfInputs(j)=Row.fromSeq(currentTransactionInputStructArray)
-				j+=1
-			}
-			currentTransactionStructArray(5)=currentTransactionListOfInputs
-			val currentTransactionListOfOutputs = new Array[Any](currentTransaction.getListOfOutputs().size())
-			// map outputs
-			j=0;
-			for (currentTransactionOutput <-currentTransaction.getListOfOutputs) {
-				val currentTransactionOutputStructArray = new Array[Any](3)
-				currentTransactionOutputStructArray(0) = currentTransactionOutput.getValue
-				currentTransactionOutputStructArray(1) = currentTransactionOutput.getTxOutScriptLength
-				currentTransactionOutputStructArray(2) = currentTransactionOutput.getTxOutScript
-				currentTransactionListOfOutputs(j)=Row.fromSeq(currentTransactionOutputStructArray)
-				j+=1
-			}
-			currentTransactionStructArray(6)=currentTransactionListOfOutputs
+  override def buildScan: RDD[Row] = {
+    val bitcoinBlockRDD: RDD[(BytesWritable, BitcoinBlock)] = readRawBlockRDD()
 
+    bitcoinBlockRDD
+      .map { case (_, currentBlock) =>
+        val transactions = currentBlock.getTransactions
+          .map { currentTransaction =>
+            val inputs = currentTransaction.getListOfInputs
+              .map { currentTransactionInput =>
+                Seq(
+                  currentTransactionInput.getPrevTransactionHash,
+                  currentTransactionInput.getPreviousTxOutIndex,
+                  currentTransactionInput.getTxInScriptLength,
+                  currentTransactionInput.getTxInScript,
+                  currentTransactionInput.getSeqNo
+                )
+              }
 
-      // map scriptWitness
-      val currentTransactionListOfScriptWitnessItem = new Array[Any](currentTransaction.getBitcoinScriptWitness().size())
-      j=0;
-      for (currentTransactionScriptWitnessItem <-currentTransaction.getBitcoinScriptWitness) {
-        val currentTransactionScriptWitnessStructArray = new Array[Any](2)
-        currentTransactionScriptWitnessStructArray(0) = currentTransactionScriptWitnessItem.getStackItemCounter
-        val currentScriptWitnessListStructArray = new Array[Any](currentTransactionScriptWitnessItem.getScriptWitnessList().size())
-        var k=0;
-        for (currentScriptWitness <- currentTransactionScriptWitnessItem.getScriptWitnessList) {
-              val currentScriptWitnessStructArray = new Array[Any](2)
-              currentScriptWitnessStructArray(0)= currentScriptWitness.getWitnessScriptLength
-              currentScriptWitnessStructArray(1)= currentScriptWitness.getWitnessScript
-              currentScriptWitnessListStructArray(k)=Row.fromSeq(currentScriptWitnessStructArray)
-             k+=1
-        }
-        currentTransactionScriptWitnessStructArray(1) = currentScriptWitnessListStructArray
-        currentTransactionListOfScriptWitnessItem(j)=Row.fromSeq(currentTransactionScriptWitnessStructArray)
-        j+=1
-      }
-      currentTransactionStructArray(7)=currentTransactionListOfScriptWitnessItem
+            val outputs = currentTransaction.getListOfOutputs
+              .map { currentTransactionOutput =>
+                Seq(
+                  currentTransactionOutput.getValue,
+                  currentTransactionOutput.getTxOutScriptLength,
+                  currentTransactionOutput.getTxOutScript
+                )
+              }
 
-      // locktime
-			currentTransactionStructArray(8)=currentTransaction.getLockTime
-      if (enrich) {
-          currentTransactionStructArray(9)=BitcoinUtil.getTransactionHash(currentTransaction)
-      }
-			transactionArray(i)=Row.fromSeq(currentTransactionStructArray)
+            val scriptWitnesses = currentTransaction.getBitcoinScriptWitness
+              .map { currentTransactionScriptWitnessItem =>
+                Seq(
+                  currentTransactionScriptWitnessItem.getStackItemCounter,
+                  currentTransactionScriptWitnessItem.getScriptWitnessList
+                    .map { currentScriptWitness =>
+                      Seq(
+                        currentScriptWitness.getWitnessScriptLength,
+                        currentScriptWitness.getWitnessScript
+                      )
+                    }
+                    .map(Row.fromSeq)
+                    .toArray
+                )
+              }
 
-			i+=1
-		}
-		rowArray(9) = transactionArray
-    if (readAuxPOW) { // add auxPow information
-      val auxPowStructArray = new Array[Any](6)
-        // version
-        auxPowStructArray(0) = hadoopKeyValueTuple._2.getAuxPOW.getVersion
-        // coinbaseTransaction
-        val coinbaseTransactionStructArray = new Array[Any](6)
-          // version
-          coinbaseTransactionStructArray(0)=hadoopKeyValueTuple._2.getAuxPOW.getCoinbaseTransaction.getVersion
-          // inCounter
-          coinbaseTransactionStructArray(1)=hadoopKeyValueTuple._2.getAuxPOW.getCoinbaseTransaction.getInCounter
-          // outCounter
-          coinbaseTransactionStructArray(2)=hadoopKeyValueTuple._2.getAuxPOW.getCoinbaseTransaction.getOutCounter
-          // listOfInputs
-          val currentCoinBaseTransactionListOfInputs = new Array[Any](hadoopKeyValueTuple._2.getAuxPOW.getCoinbaseTransaction.getListOfInputs.size())
-          var j=0;
-          for (currentCoinBaseTransactionInput <- hadoopKeyValueTuple._2.getAuxPOW.getCoinbaseTransaction.getListOfInputs) {
-            val coinbaseTransactionInputStruct = new Array[Any](5)
-             // prevTransactionHash
-             coinbaseTransactionInputStruct(0)=currentCoinBaseTransactionInput.getPrevTransactionHash
-             // previousTxOutIndex
-             coinbaseTransactionInputStruct(1)=currentCoinBaseTransactionInput.getPreviousTxOutIndex
-             // txInScriptLength
-             coinbaseTransactionInputStruct(2)=currentCoinBaseTransactionInput.getTxInScriptLength
-             // txInScript
-             coinbaseTransactionInputStruct(3)=currentCoinBaseTransactionInput.getTxInScript
-             // seqNo
-             coinbaseTransactionInputStruct(4)=currentCoinBaseTransactionInput.getSeqNo
-             currentCoinBaseTransactionListOfInputs(j)=Row.fromSeq(coinbaseTransactionInputStruct)
-             j+=1
+            val transaction = Seq(
+              currentTransaction.getVersion,
+              currentTransaction.getMarker,
+              currentTransaction.getFlag,
+              currentTransaction.getInCounter,
+              currentTransaction.getOutCounter,
+              inputs.map(Row.fromSeq).toArray,
+              outputs.map(Row.fromSeq).toArray,
+              scriptWitnesses.map(Row.fromSeq).toArray,
+              currentTransaction.getLockTime
+            )
+
+            if (enrich) {
+              transaction :+ BitcoinUtil.getTransactionHash(currentTransaction)
+            } else {
+              transaction
+            }
           }
-          coinbaseTransactionStructArray(3)=currentCoinBaseTransactionListOfInputs
-          // listOfOutputs
-          val currentCoinBaseTransactionListOfOutputs = new Array[Any](hadoopKeyValueTuple._2.getAuxPOW.getCoinbaseTransaction.getListOfOutputs.size())
-          j=0;
-          for (currentCoinBaseTransactionOutput <- hadoopKeyValueTuple._2.getAuxPOW.getCoinbaseTransaction.getListOfOutputs) {
-          val coinbaseTransactionOutputStruct = new Array[Any](3)
-            // value
-            coinbaseTransactionOutputStruct(0)=currentCoinBaseTransactionOutput.getValue
-            // txOutScriptLength
-            coinbaseTransactionOutputStruct(1)=currentCoinBaseTransactionOutput.getTxOutScriptLength
-            // txOutScript
-            coinbaseTransactionOutputStruct(2)=currentCoinBaseTransactionOutput.getTxOutScript
-            currentCoinBaseTransactionListOfOutputs(j)=Row.fromSeq(coinbaseTransactionOutputStruct)
-            j+=1
-          }
-            coinbaseTransactionStructArray(4)=currentCoinBaseTransactionListOfOutputs
-          // locktime
-          coinbaseTransactionStructArray(5)=hadoopKeyValueTuple._2.getAuxPOW.getCoinbaseTransaction.getLockTime
-        auxPowStructArray(1)=Row.fromSeq(coinbaseTransactionStructArray)
-        // parentBlockHeaderHash
-        auxPowStructArray(2)=hadoopKeyValueTuple._2.getAuxPOW.getParentBlockHeaderHash
-        // coinbaseBranch
-        val coinbaseBranchStructArray = new Array[Any](3)
-        coinbaseBranchStructArray(0)=hadoopKeyValueTuple._2.getAuxPOW.getCoinbaseBranch.getNumberOfLinks
-        val coinbaseBranchLinks = new Array[Any](hadoopKeyValueTuple._2.getAuxPOW.getCoinbaseBranch.getLinks.size())
-        j=0
-        for (currentCoinbaseBranchLink <- hadoopKeyValueTuple._2.getAuxPOW.getCoinbaseBranch.getLinks) {
-          coinbaseBranchLinks(j)=currentCoinbaseBranchLink
-          j+=1
-        }
-        coinbaseBranchStructArray(1)=coinbaseBranchLinks
-        coinbaseBranchStructArray(2)=hadoopKeyValueTuple._2.getAuxPOW.getCoinbaseBranch.getBranchSideBitmask
-        auxPowStructArray(3)=Row.fromSeq(coinbaseBranchStructArray)
-        // auxBlockChainBranch
-        val auxBlockChainBranchStructArray = new Array[Any](3)
-        auxBlockChainBranchStructArray(0)=hadoopKeyValueTuple._2.getAuxPOW.getAuxBlockChainBranch.getNumberOfLinks
-        val auxBlockChainBranchLinks = new Array[Any](hadoopKeyValueTuple._2.getAuxPOW.getAuxBlockChainBranch.getLinks.size())
-        j=0
-        for (currentAuxBlockChainBranchLink <- hadoopKeyValueTuple._2.getAuxPOW.getAuxBlockChainBranch.getLinks) {
-          auxBlockChainBranchLinks(j)=currentAuxBlockChainBranchLink
-          j+=1
-        }
-        auxBlockChainBranchStructArray(1)=auxBlockChainBranchLinks
-        auxBlockChainBranchStructArray(2)=hadoopKeyValueTuple._2.getAuxPOW.getCoinbaseBranch.getBranchSideBitmask
-        auxPowStructArray(4)=Row.fromSeq(auxBlockChainBranchStructArray)
-        // parentBlockHeader
-        val parentBlockHeaderStructArray = new Array[Any](6)
-        parentBlockHeaderStructArray(0)=hadoopKeyValueTuple._2.getAuxPOW.getParentBlockHeader.getVersion
-        parentBlockHeaderStructArray(1)=hadoopKeyValueTuple._2.getAuxPOW.getParentBlockHeader.getPreviousBlockHash
-        parentBlockHeaderStructArray(2)=hadoopKeyValueTuple._2.getAuxPOW.getParentBlockHeader.getMerkleRoot
-        parentBlockHeaderStructArray(3)=hadoopKeyValueTuple._2.getAuxPOW.getParentBlockHeader.getTime
-        parentBlockHeaderStructArray(4)=hadoopKeyValueTuple._2.getAuxPOW.getParentBlockHeader.getBits
-        parentBlockHeaderStructArray(5)=hadoopKeyValueTuple._2.getAuxPOW.getParentBlockHeader.getNonce
-        auxPowStructArray(5)=Row.fromSeq(parentBlockHeaderStructArray)
-      rowArray(10) =Row.fromSeq(auxPowStructArray)
-    }
-	 	// add row representing one Bitcoin Block
-          	Some(Row.fromSeq(rowArray))
-		}
+
+        val block = Seq(
+          currentBlock.getBlockSize,
+          currentBlock.getMagicNo,
+          currentBlock.getVersion,
+          currentBlock.getTime,
+          currentBlock.getBits,
+          currentBlock.getNonce,
+          currentBlock.getTransactionCounter,
+          currentBlock.getHashPrevBlock,
+          currentBlock.getHashMerkleRoot,
+          transactions.map(Row.fromSeq).toArray
         )
 
-     }
+        if (readAuxPOW) {
+          block :+ Row.fromSeq(getAuxPOW(currentBlock.getAuxPOW))
+        } else {
+          block
+        }
+      }
+      .map(Row.fromSeq)
+  }
 
+  private def getAuxPOW(auxPOW: BitcoinAuxPOW): Seq[Any] = {
+    val inputs = auxPOW.getCoinbaseTransaction.getListOfInputs
+      .map { currentCoinBaseTransactionInput =>
+        Seq(
+          currentCoinBaseTransactionInput.getPrevTransactionHash,
+          currentCoinBaseTransactionInput.getPreviousTxOutIndex,
+          currentCoinBaseTransactionInput.getTxInScriptLength,
+          currentCoinBaseTransactionInput.getTxInScript,
+          currentCoinBaseTransactionInput.getSeqNo
+        )
+      }
+      .map(Row.fromSeq)
+      .toArray
 
+    val outputs = auxPOW.getCoinbaseTransaction.getListOfOutputs
+      .map { currentCoinBaseTransactionOutput =>
+        Seq(
+          currentCoinBaseTransactionOutput.getValue,
+          currentCoinBaseTransactionOutput.getTxOutScriptLength,
+          currentCoinBaseTransactionOutput.getTxOutScript
+        )
+      }
+      .map(Row.fromSeq)
+      .toArray
+
+    val coinbaseTransaction = Seq(
+      auxPOW.getCoinbaseTransaction.getVersion,
+      auxPOW.getCoinbaseTransaction.getInCounter,
+      auxPOW.getCoinbaseTransaction.getOutCounter,
+      inputs,
+      outputs,
+      auxPOW.getCoinbaseTransaction.getLockTime
+    )
+
+    val coinbaseBranch = Seq(
+      auxPOW.getCoinbaseBranch.getNumberOfLinks,
+      auxPOW.getCoinbaseBranch.getLinks.toArray,
+      auxPOW.getCoinbaseBranch.getBranchSideBitmask
+    )
+
+    val auxBlockChainBranch = Seq(
+      auxPOW.getAuxBlockChainBranch.getNumberOfLinks,
+      auxPOW.getAuxBlockChainBranch.getLinks.toArray,
+      auxPOW.getCoinbaseBranch.getBranchSideBitmask
+    )
+
+    val parentBlockHeader = Seq(
+      auxPOW.getParentBlockHeader.getVersion,
+      auxPOW.getParentBlockHeader.getPreviousBlockHash,
+      auxPOW.getParentBlockHeader.getMerkleRoot,
+      auxPOW.getParentBlockHeader.getTime,
+      auxPOW.getParentBlockHeader.getBits,
+      auxPOW.getParentBlockHeader.getNonce
+    )
+
+    val auxPOWData = Seq(
+      auxPOW.getVersion,
+      Row.fromSeq(coinbaseTransaction),
+      auxPOW.getParentBlockHeaderHash,
+      Row.fromSeq(coinbaseBranch),
+      Row.fromSeq(auxBlockChainBranch),
+      Row.fromSeq(parentBlockHeader)
+    )
+    auxPOWData
+  }
+
+  private def readRawBlockRDD(): RDD[(BytesWritable, BitcoinBlock)] = {
+    // create hadoopConf
+    val hadoopConf = new Configuration()
+    hadoopConf.set(AbstractBitcoinRecordReader.CONF_MAXBLOCKSIZE, String.valueOf(maxBlockSize))
+    hadoopConf.set(AbstractBitcoinRecordReader.CONF_FILTERMAGIC, magic)
+    hadoopConf.set(AbstractBitcoinRecordReader.CONF_USEDIRECTBUFFER, String.valueOf(useDirectBuffer))
+    hadoopConf.set(AbstractBitcoinFileInputFormat.CONF_ISSPLITABLE, String.valueOf(isSplittable))
+    hadoopConf.set(AbstractBitcoinRecordReader.CONF_READAUXPOW, String.valueOf(readAuxPOW))
+    // read BitcoinBlock
+    BitcoinBlockFile.load(sqlContext, location, hadoopConf)
+  }
 }

--- a/src/main/scala/org/zuinnote/spark/bitcoin/block/DefaultSource.scala
+++ b/src/main/scala/org/zuinnote/spark/bitcoin/block/DefaultSource.scala
@@ -1,60 +1,49 @@
 /**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+  * Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 package org.zuinnote.spark.bitcoin.block
 
-import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.{DataFrame, SaveMode, SQLContext}
+import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.sources._
-import org.apache.spark.sql.types.StructType
-
 import org.zuinnote.hadoop.bitcoin.format.mapreduce._
 
 /**
-* Author: Jörn Franke <zuinnote@gmail.com>
-*
-*/
+  * Author: Jörn Franke <zuinnote@gmail.com>
+  *
+  * Defines a Spark data source for Bitcoin Blockchcain based on hadoopcryptoledgerlibrary. This is read-only for existing data. It returns BitcoinBlocks.
+  */
+class DefaultSource extends RelationProvider {
+  /**
+    * Used by Spark to fetch information about the data and initiate parsing
+    */
+  override def createRelation(sqlContext: SQLContext, parameters: Map[String, String]): BitcoinBlockRelation = {
+    val path =
+      parameters.getOrElse("path", sys.error("'path' must be specified with files containing Bitcoin blockchain data."))
+    val maxBlockSize = Integer.valueOf(
+      parameters.getOrElse("maxBlockSize", String.valueOf(AbstractBitcoinRecordReader.DEFAULT_MAXSIZE_BITCOINBLOCK)))
+    val magic = parameters.getOrElse("magic", AbstractBitcoinRecordReader.DEFAULT_MAGIC)
+    val useDirectBuffer = parameters
+      .getOrElse("useDirectBuffer", String.valueOf(AbstractBitcoinRecordReader.DEFAULT_USEDIRECTBUFFER))
+      .toBoolean
+    val isSplittable =
+      parameters.getOrElse("isSplittable", String.valueOf(AbstractBitcoinFileInputFormat.DEFAULT_ISSPLITABLE)).toBoolean
+    val readAuxPOW =
+      parameters.getOrElse("readAuxPOW", String.valueOf(AbstractBitcoinRecordReader.DEFAULT_READAUXPOW)).toBoolean
+    val enrich = parameters.getOrElse("enrich", "false").toBoolean
 
-/**
-*
-* Defines a Spark data source for Bitcoin Blockchcain based on hadoopcryptoledgerlibrary. This is read-only for existing data. It returns BitcoinBlocks.
-*
-*/
-
-class DefaultSource
-  extends RelationProvider
-   {
-
-	/**
-	 * Used by Spark to fetch information about the data and initiate parsing
-	 *
-	*
-	*/
-  override def createRelation(
-      sqlContext: SQLContext,
-      parameters: Map[String, String]): BitcoinBlockRelation = {
-      val path= parameters.getOrElse("path", sys.error("'path' must be specified with files containing Bitcoin blockchain data."))
-      val maxBlockSize = Integer.valueOf(parameters.getOrElse("maxBlockSize", String.valueOf(AbstractBitcoinRecordReader.DEFAULT_MAXSIZE_BITCOINBLOCK)))
-      val magic = parameters.getOrElse("magic", AbstractBitcoinRecordReader.DEFAULT_MAGIC)
-      val useDirectBuffer = parameters.getOrElse("useDirectBuffer", String.valueOf(AbstractBitcoinRecordReader.DEFAULT_USEDIRECTBUFFER)).toBoolean
-      val isSplitable = parameters.getOrElse("isSplitable", String.valueOf(AbstractBitcoinFileInputFormat.DEFAULT_ISSPLITABLE)).toBoolean
-      val readAuxPOW = parameters.getOrElse("readAuxPOW", String.valueOf(AbstractBitcoinRecordReader.DEFAULT_READAUXPOW)).toBoolean
-      val enrich = parameters.getOrElse("enrich", "false").toBoolean
-      // parse the parameters into hadoop objects
-      BitcoinBlockRelation(path, maxBlockSize, magic, useDirectBuffer, isSplitable,readAuxPOW,enrich)(sqlContext)
+    // parse the parameters into hadoop objects
+    BitcoinBlockRelation(path, maxBlockSize, magic, useDirectBuffer, isSplittable, readAuxPOW, enrich)(sqlContext)
   }
-
-
 }

--- a/src/main/scala/org/zuinnote/spark/bitcoin/block/DefaultSource15.scala
+++ b/src/main/scala/org/zuinnote/spark/bitcoin/block/DefaultSource15.scala
@@ -1,40 +1,35 @@
 /**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+  * Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 package org.zuinnote.spark.bitcoin.block
 
 import org.apache.spark.sql.sources.DataSourceRegister
 
-import org.zuinnote.hadoop.bitcoin.format._
-   
 /**
-* Author: Jörn Franke <zuinnote@gmail.com>
-*
-*/
-
-/* Extension of DefaultSource (which is Spark 1.3 and 1.4 compatible) for Spark 1.5 compatibility.
- * Since the class is loaded through META-INF/services we can decouple the two to have
- * Spark 1.5 byte-code loaded lazily.
- *
- * This trick is adapted from spark elasticsearch-hadoop data source:
- * <https://github.com/elastic/elasticsearch-hadoop>
- */
+  * Author: Jörn Franke <zuinnote@gmail.com>
+  * Extension of DefaultSource (which is Spark 1.3 and 1.4 compatible) for Spark 1.5 compatibility.
+  * Since the class is loaded through META-INF/services we can decouple the two to have
+  * Spark 1.5 byte-code loaded lazily.
+  *
+  * This trick is adapted from spark elasticsearch-hadoop data source:
+  * <https://github.com/elastic/elasticsearch-hadoop>
+  */
 class DefaultSource15 extends DefaultSource with DataSourceRegister {
 
   /**
-   * Short alias for hadoopcryptoledger BitcoinBlock data source.
-   */
+    * Short alias for hadoopcryptoledger BitcoinBlock data source.
+    */
   override def shortName(): String = "bitcoinblock"
 }

--- a/src/main/scala/org/zuinnote/spark/bitcoin/block/package.scala
+++ b/src/main/scala/org/zuinnote/spark/bitcoin/block/package.scala
@@ -1,53 +1,39 @@
 /**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
-package org.zuinnote.spark.bitcoin.block
-
+  * Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
+package org.zuinnote.spark.bitcoin
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
-
-import org.zuinnote.hadoop.bitcoin.format.common._
-import org.zuinnote.hadoop.bitcoin.format.mapreduce._   
-
-   
-/**
-* Author: Jörn Franke <zuinnote@gmail.com>
-*
-*/
-
-
-
-package object bitcoinblock {
+import org.zuinnote.hadoop.bitcoin.format.mapreduce._
 
 /**
-   * Adds a method, `bitcoinBlockFile`, to SQLContext that allows reading Bitcoin blockchain data as Bitcoin blocks.
-   */
-
- implicit class BitcoinBlockContext(sqlContext: SQLContext) extends Serializable{
-def bitcoinBlockFile(
-        filePath: String,
-	maxBlockSize: Integer = AbstractBitcoinRecordReader.DEFAULT_MAXSIZE_BITCOINBLOCK,
-	magic: String = AbstractBitcoinRecordReader.DEFAULT_MAGIC,
-	useDirectBuffer: Boolean = AbstractBitcoinRecordReader.DEFAULT_USEDIRECTBUFFER,
-	isSplitable: Boolean = AbstractBitcoinFileInputFormat.DEFAULT_ISSPLITABLE
-       ): DataFrame = {
-      val bitcoinBlockRelation = BitcoinBlockRelation(filePath,maxBlockSize,magic,useDirectBuffer,isSplitable)(sqlContext)
+  * Author: Jörn Franke <zuinnote@gmail.com>
+  */
+package object block {
+  /**
+    * Adds a method, `bitcoinBlockFile`, to SQLContext that allows reading Bitcoin blockchain data as Bitcoin blocks.
+    */
+  implicit class BitcoinBlockContext(sqlContext: SQLContext) extends Serializable {
+    def bitcoinBlockFile(filePath: String,
+                         maxBlockSize: Integer = AbstractBitcoinRecordReader.DEFAULT_MAXSIZE_BITCOINBLOCK,
+                         magic: String = AbstractBitcoinRecordReader.DEFAULT_MAGIC,
+                         useDirectBuffer: Boolean = AbstractBitcoinRecordReader.DEFAULT_USEDIRECTBUFFER,
+                         isSplittable: Boolean = AbstractBitcoinFileInputFormat.DEFAULT_ISSPLITABLE): DataFrame = {
+      val bitcoinBlockRelation =
+        BitcoinBlockRelation(filePath, maxBlockSize, magic, useDirectBuffer, isSplittable)(sqlContext)
       sqlContext.baseRelationToDataFrame(bitcoinBlockRelation)
-}
-}
-
-
-
+    }
+  }
 }

--- a/src/main/scala/org/zuinnote/spark/bitcoin/model/BitcoinBlock.scala
+++ b/src/main/scala/org/zuinnote/spark/bitcoin/model/BitcoinBlock.scala
@@ -11,11 +11,33 @@ final case class ScriptWitnessItem(stackItemCounter: Array[Byte], scriptWitnessL
 
 final case class Transaction(version: Int, marker: Byte, flag: Byte, inCounter: Array[Byte], outCounter: Array[Byte],
                              listOfInputs: Seq[Input], listOfOutputs: Seq[Output],
-                             listOfScriptWitnessItem: Seq[ScriptWitnessItem], lockTime: Int)
+                             listOfScriptWitnessItem: Seq[ScriptWitnessItem], lockTime: Int) {
+  
+  private[bitcoin] def enriched(currentTransactionHash: Array[Byte]): EnrichedTransaction = {
+    EnrichedTransaction(
+      version, marker, flag, inCounter, outCounter, listOfInputs, listOfOutputs, listOfScriptWitnessItem, lockTime,
+      currentTransactionHash
+    )
+  }
+}
 
 final case class BitcoinBlock(blockSize: Int, magicNo: Array[Byte], version: Int, time: Int, bits: Array[Byte],
                               nonce: Int, transactionCounter: Long, hashPrevBlock: Array[Byte],
-                              hashMerkleRoot: Array[Byte], transactions: Seq[Transaction])
+                              hashMerkleRoot: Array[Byte], transactions: Seq[Transaction]) {
+
+  private[bitcoin] def withAuxPOW(auxPOW: AuxPOW): BitcoinBlockWithAuxPOW = {
+    BitcoinBlockWithAuxPOW(
+      blockSize, magicNo, version, time, bits, nonce, transactionCounter, hashPrevBlock, hashMerkleRoot, transactions,
+      auxPOW
+    )
+  }
+
+  private[bitcoin] def enriched(transactions: Seq[EnrichedTransaction]): EnrichedBitcoinBlock = {
+    EnrichedBitcoinBlock(
+      blockSize, magicNo, version, time, bits, nonce, transactionCounter, hashPrevBlock, hashMerkleRoot, transactions
+    )
+  }
+}
 
 final case class BitcoinBlockWithAuxPOW(blockSize: Int, magicNo: Array[Byte], version: Int, time: Int,
                                         bits: Array[Byte], nonce: Int, transactionCounter: Long,
@@ -29,7 +51,15 @@ final case class EnrichedTransaction(version: Int, marker: Byte, flag: Byte, inC
 
 final case class EnrichedBitcoinBlock(blockSize: Int, magicNo: Array[Byte], version: Int, time: Int, bits: Array[Byte],
                                       nonce: Int, transactionCounter: Long, hashPrevBlock: Array[Byte],
-                                      hashMerkleRoot: Array[Byte], transactions: Seq[EnrichedTransaction])
+                                      hashMerkleRoot: Array[Byte], transactions: Seq[EnrichedTransaction]) {
+
+  private[bitcoin] def withAuxPOW(auxPOW: AuxPOW): EnrichedBitcoinBlockWithAuxPOW = {
+    EnrichedBitcoinBlockWithAuxPOW(
+      blockSize, magicNo, version, time, bits, nonce, transactionCounter, hashPrevBlock, hashMerkleRoot, transactions,
+      auxPOW
+    )
+  }
+}
 
 final case class EnrichedBitcoinBlockWithAuxPOW(blockSize: Int, magicNo: Array[Byte], version: Int, time: Int,
                                                 bits: Array[Byte], nonce: Int, transactionCounter: Long,

--- a/src/main/scala/org/zuinnote/spark/bitcoin/transaction/BitcoinTransactionRelation.scala
+++ b/src/main/scala/org/zuinnote/spark/bitcoin/transaction/BitcoinTransactionRelation.scala
@@ -1,183 +1,175 @@
 /**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+  * Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 package org.zuinnote.spark.bitcoin.transaction
+
+import org.apache.commons.logging.LogFactory
+import org.apache.hadoop.conf._
+import org.apache.hadoop.io.BytesWritable
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{SQLContext, _}
+import org.apache.spark.sql.sources.{BaseRelation, TableScan}
+import org.apache.spark.sql.types._
+import org.zuinnote.hadoop.bitcoin.format.common.BitcoinTransaction
+import org.zuinnote.hadoop.bitcoin.format.mapreduce._
+import org.zuinnote.spark.bitcoin.util.BitcoinTransactionFile
 
 import scala.collection.JavaConversions._
 
-import org.apache.spark.sql.sources.{BaseRelation,TableScan}
-import org.apache.spark.sql.types.DataType
-import org.apache.spark.sql.types.ArrayType
-import org.apache.spark.sql.types.ByteType
-import org.apache.spark.sql.types.BinaryType
-import org.apache.spark.sql.types.IntegerType
-import org.apache.spark.sql.types.LongType
-import org.apache.spark.sql.types.StructField
-import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.SQLContext
-
-
-
-import org.apache.spark.sql._
-import org.apache.spark.rdd.RDD
-
-import org.apache.hadoop.conf._
-import org.apache.hadoop.mapred._
-
-
-
-import org.apache.commons.logging.LogFactory
-import org.apache.commons.logging.Log
-
-import org.zuinnote.hadoop.bitcoin.format.common._
-import org.zuinnote.hadoop.bitcoin.format.mapreduce._
-
-import org.zuinnote.spark.bitcoin.util.BitcoinTransactionFile
-
 /**
-* Author: Jörn Franke <zuinnote@gmail.com>
-*
-*/
-
+  * Author: Jörn Franke <zuinnote@gmail.com>
+  *
+  */
 /**
-* Defines the schema of a BitcoinTransaction for Spark SQL
-*
-*/
+  * Defines the schema of a BitcoinTransaction for Spark SQL
+  *
+  */
+case class BitcoinTransactionRelation(
+                                       location: String,
+                                       maxBlockSize: Integer = AbstractBitcoinRecordReader.DEFAULT_MAXSIZE_BITCOINBLOCK,
+                                       magic: String = AbstractBitcoinRecordReader.DEFAULT_MAGIC,
+                                       useDirectBuffer: Boolean = AbstractBitcoinRecordReader.DEFAULT_USEDIRECTBUFFER,
+                                       isSplittable: Boolean = AbstractBitcoinFileInputFormat.DEFAULT_ISSPLITABLE,
+                                       readAuxPOW: Boolean = AbstractBitcoinRecordReader.DEFAULT_READAUXPOW)
+                                     (@transient val sqlContext: SQLContext)
+  extends BaseRelation
+    with TableScan
+    with Serializable {
 
-case class BitcoinTransactionRelation(location: String,maxBlockSize: Integer = AbstractBitcoinRecordReader.DEFAULT_MAXSIZE_BITCOINBLOCK,magic: String = AbstractBitcoinRecordReader.DEFAULT_MAGIC,useDirectBuffer: Boolean = AbstractBitcoinRecordReader.DEFAULT_USEDIRECTBUFFER,isSplitable: Boolean = AbstractBitcoinFileInputFormat.DEFAULT_ISSPLITABLE,readAuxPOW: Boolean = AbstractBitcoinRecordReader.DEFAULT_READAUXPOW)
-(@transient val sqlContext: SQLContext)
-  extends BaseRelation with TableScan
-       with Serializable {
-  val LOG = LogFactory.getLog(BitcoinTransactionRelation.getClass);
+  private lazy val LOG = LogFactory.getLog(BitcoinTransactionRelation.getClass)
 
-  override def schema: StructType = {
-
-      return StructType(Seq(StructField("currentTransactionHash",BinaryType,false),
-					StructField("version", IntegerType, false),
-          StructField("marker", ByteType, false),
-          StructField("flag", ByteType, false),
-					StructField("inCounter", BinaryType, false),
-					StructField("outCounter", BinaryType, false),
-					StructField("listOfInputs",ArrayType(StructType(Seq(
-						StructField("prevTransactionHash",BinaryType,false),
-						StructField("previousTxOutIndex",LongType,false),
-						StructField("txInScriptLength",BinaryType,false),
-						StructField("txInScript",BinaryType,false),
-						StructField("seqNo",LongType,false)))),false),
-					StructField("listOfOutputs",ArrayType(StructType(Seq(
-						StructField("value",LongType,false),
-						StructField("txOutScriptLength",BinaryType,false),
-						StructField("txOutScript",BinaryType,false)))),false),
-          StructField("listOfScriptWitnessItem",ArrayType(StructType(Seq(
-    						StructField("stackItemCounter",BinaryType,false),
-                StructField("scriptWitnessList",ArrayType(StructType(Seq(
-                  StructField("witnessScriptLength",BinaryType,false),
-                  StructField("witnessScript",BinaryType,false)
-                )), false)
-    						))), false)),
-					StructField("lockTime", IntegerType, false)))
-    }
-
-
-    /**
-     * Used by Spark to fetch Bitcoin transactions according to the schema specified above from files.
-     *
-     *
-     * returns BitcoinTransactions as rows
-    **/
-    override def buildScan: RDD[Row] = {
-	// create hadoopConf
-	val hadoopConf = new Configuration()
- 	hadoopConf.set(AbstractBitcoinRecordReader.CONF_MAXBLOCKSIZE,String.valueOf(maxBlockSize))
- 	hadoopConf.set(AbstractBitcoinRecordReader.CONF_FILTERMAGIC,magic)
- 	hadoopConf.set(AbstractBitcoinRecordReader.CONF_USEDIRECTBUFFER,String.valueOf(useDirectBuffer))
- 	hadoopConf.set(AbstractBitcoinFileInputFormat.CONF_ISSPLITABLE, String.valueOf(isSplitable))
-        // read BitcoinBlock
-	val bitcoinTransactionRDD = BitcoinTransactionFile.load(sqlContext, location, hadoopConf)
-        // map to schema
-	val schemaFields = schema.fields
-	val rowArray = new Array[Any](schemaFields.length)
-        bitcoinTransactionRDD.flatMap(hadoopKeyValueTuple => {
-		// map the BitcoinTransaction data structure to a Spark SQL schema
-
-		// map transactions
-
-			val currentTransaction=hadoopKeyValueTuple._2
-			rowArray(0)=hadoopKeyValueTuple._1.copyBytes // current transaction hash
-			rowArray(1)=currentTransaction.getVersion
-      rowArray(2)=currentTransaction.getMarker
-      rowArray(3)=currentTransaction.getFlag
-			rowArray(4)=currentTransaction.getInCounter
-			rowArray(5)=currentTransaction.getOutCounter
-			val currentTransactionListOfInputs = new Array[Any](currentTransaction.getListOfInputs().size())
-			// map inputs
-			var j=0
-			for (currentTransactionInput <-currentTransaction.getListOfInputs) {
-				val currentTransactionInputStructArray = new Array[Any](5)
-				currentTransactionInputStructArray(0)=currentTransactionInput.getPrevTransactionHash
-				currentTransactionInputStructArray(1)=currentTransactionInput.getPreviousTxOutIndex
-				currentTransactionInputStructArray(2)=currentTransactionInput.getTxInScriptLength
-				currentTransactionInputStructArray(3)=currentTransactionInput.getTxInScript
-				currentTransactionInputStructArray(4)=currentTransactionInput.getSeqNo
-
-				currentTransactionListOfInputs(j)=Row.fromSeq(currentTransactionInputStructArray)
-				j+=1
-			}
-			rowArray(6)=currentTransactionListOfInputs
-			val currentTransactionListOfOutputs = new Array[Any](currentTransaction.getListOfOutputs().size())
-			// map outputs
-			j=0;
-			for (currentTransactionOutput <-currentTransaction.getListOfOutputs) {
-				val currentTransactionOutputStructArray = new Array[Any](3)
-				currentTransactionOutputStructArray(0) = currentTransactionOutput.getValue
-				currentTransactionOutputStructArray(1) = currentTransactionOutput.getTxOutScriptLength
-				currentTransactionOutputStructArray(2) = currentTransactionOutput.getTxOutScript
-				currentTransactionListOfOutputs(j)=Row.fromSeq(currentTransactionOutputStructArray)
-				j+=1
-			}
-			rowArray(7)=currentTransactionListOfOutputs
-      // map scriptWitness
-      val currentTransactionListOfScriptWitnessItem = new Array[Any](currentTransaction.getBitcoinScriptWitness().size())
-      j=0;
-      for (currentTransactionScriptWitnessItem <-currentTransaction.getBitcoinScriptWitness) {
-        val currentTransactionScriptWitnessStructArray = new Array[Any](2)
-        currentTransactionScriptWitnessStructArray(0) = currentTransactionScriptWitnessItem.getStackItemCounter
-        val currentScriptWitnessListStructArray = new Array[Any](currentTransactionScriptWitnessItem.getScriptWitnessList().size())
-        var k=0;
-        for (currentScriptWitness <- currentTransactionScriptWitnessItem.getScriptWitnessList) {
-              val currentScriptWitnessStructArray = new Array[Any](2)
-              currentScriptWitnessStructArray(0)= currentScriptWitness.getWitnessScriptLength
-              currentScriptWitnessStructArray(1)= currentScriptWitness.getWitnessScript
-              currentScriptWitnessListStructArray(k)=Row.fromSeq(currentScriptWitnessStructArray)
-             k+=1
-        }
-        currentTransactionScriptWitnessStructArray(1) = currentScriptWitnessListStructArray
-        currentTransactionListOfScriptWitnessItem(j)=Row.fromSeq(currentTransactionScriptWitnessStructArray)
-        j+=1
-      }
-      rowArray(8)=currentTransactionListOfScriptWitnessItem
-			rowArray(9)=currentTransaction.getLockTime
-
-		// add row representing one Bitcoin Transaction
-          	Some(Row.fromSeq(rowArray))
-
-		}
-
+  override def schema: StructType = StructType(
+    Seq(
+      StructField("currentTransactionHash", BinaryType, nullable = false),
+      StructField("version", IntegerType, nullable = false),
+      StructField("marker", ByteType, nullable = false),
+      StructField("flag", ByteType, nullable = false),
+      StructField("inCounter", BinaryType, nullable = false),
+      StructField("outCounter", BinaryType, nullable = false),
+      StructField(
+        "listOfInputs",
+        ArrayType(StructType(Seq(
+          StructField("prevTransactionHash", BinaryType, nullable = false),
+          StructField("previousTxOutIndex", LongType, nullable = false),
+          StructField("txInScriptLength", BinaryType, nullable = false),
+          StructField("txInScript", BinaryType, nullable = false),
+          StructField("seqNo", LongType, nullable = false)
+        ))),
+        nullable = false
+      ),
+      StructField(
+        "listOfOutputs",
+        ArrayType(
+          StructType(Seq(StructField("value", LongType, nullable = false),
+            StructField("txOutScriptLength", BinaryType, nullable = false),
+            StructField("txOutScript", BinaryType, nullable = false)))),
+        nullable = false
+      ),
+      StructField(
+        "listOfScriptWitnessItem",
+        ArrayType(
+          StructType(Seq(
+            StructField("stackItemCounter", BinaryType, nullable = false),
+            StructField(
+              "scriptWitnessList",
+              ArrayType(StructType(Seq(
+                StructField("witnessScriptLength", BinaryType, nullable = false),
+                StructField("witnessScript", BinaryType, nullable = false)
+              )),
+                containsNull = false)
+            )
+          )),
+          containsNull = false
         )
+      ),
+      StructField("lockTime", IntegerType, nullable = false)
+    ))
 
-     }
+  /**
+    * Used by Spark to fetch Bitcoin transactions according to the schema specified above from files.
+    *
+    *
+    * returns BitcoinTransactions as rows
+    **/
+  override def buildScan: RDD[Row] = {
+    val bitcoinTransactionRDD: RDD[(BytesWritable, BitcoinTransaction)] = readRawTransactionRDD()
 
+    bitcoinTransactionRDD
+      .map { case (transactionHash, currentTransaction) =>
+        // map the BitcoinTransaction data structure to a Spark SQL schema
+        val inputs = currentTransaction.getListOfInputs
+          .map { currentTransactionInput =>
+            Seq(
+              currentTransactionInput.getPrevTransactionHash,
+              currentTransactionInput.getPreviousTxOutIndex,
+              currentTransactionInput.getTxInScriptLength,
+              currentTransactionInput.getTxInScript,
+              currentTransactionInput.getSeqNo
+            )
+          }
 
+        val outputs = currentTransaction.getListOfOutputs
+          .map { currentTransactionOutput =>
+            Seq(
+              currentTransactionOutput.getValue,
+              currentTransactionOutput.getTxOutScriptLength,
+              currentTransactionOutput.getTxOutScript
+            )
+          }
+
+        val scriptWitness = currentTransaction.getBitcoinScriptWitness
+          .map { currentTransactionScriptWitnessItem =>
+            Seq(
+              currentTransactionScriptWitnessItem.getStackItemCounter,
+              currentTransactionScriptWitnessItem.getScriptWitnessList
+                .map(currentScriptWitness =>
+                  Seq(
+                    currentScriptWitness.getWitnessScriptLength,
+                    currentScriptWitness.getWitnessScript
+                  )
+                )
+                .map(Row.fromSeq)
+                .toArray
+            )
+          }
+
+        Seq(
+          // map transactions
+          transactionHash.copyBytes, // current transaction hash
+          currentTransaction.getVersion,
+          currentTransaction.getMarker,
+          currentTransaction.getFlag,
+          currentTransaction.getInCounter,
+          currentTransaction.getOutCounter,
+          inputs.map(Row.fromSeq).toArray,
+          outputs.map(Row.fromSeq).toArray,
+          scriptWitness.map(Row.fromSeq).toArray,
+          currentTransaction.getLockTime
+        )
+      }
+      .map(Row.fromSeq)
+  }
+
+  private def readRawTransactionRDD(): RDD[(BytesWritable, BitcoinTransaction)] = {
+    // create hadoopConf
+    val hadoopConf = new Configuration()
+    hadoopConf.set(AbstractBitcoinRecordReader.CONF_MAXBLOCKSIZE, String.valueOf(maxBlockSize))
+    hadoopConf.set(AbstractBitcoinRecordReader.CONF_FILTERMAGIC, magic)
+    hadoopConf.set(AbstractBitcoinRecordReader.CONF_USEDIRECTBUFFER, String.valueOf(useDirectBuffer))
+    hadoopConf.set(AbstractBitcoinFileInputFormat.CONF_ISSPLITABLE, String.valueOf(isSplittable))
+    // read BitcoinBlock
+    BitcoinTransactionFile.load(sqlContext, location, hadoopConf)
+  }
 }

--- a/src/main/scala/org/zuinnote/spark/bitcoin/transaction/DefaultSource.scala
+++ b/src/main/scala/org/zuinnote/spark/bitcoin/transaction/DefaultSource.scala
@@ -1,17 +1,17 @@
 /**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+  * Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
 **/
 package org.zuinnote.spark.bitcoin.transaction
 
@@ -24,37 +24,36 @@ import org.zuinnote.hadoop.bitcoin.format.common._
 import org.zuinnote.hadoop.bitcoin.format.mapreduce._
 
 /**
-* Author: Jörn Franke <zuinnote@gmail.com>
-*
-*/
-
+  * Author: Jörn Franke <zuinnote@gmail.com>
+  *
+  */
 /**
-*
-* Defines a Spark data source for Bitcoin Blockchcain based on hadoopcryptoledgerlibrary. This is read-only for existing data. It returns BitcoinBlocks.
-*
-*/
+  *
+  * Defines a Spark data source for Bitcoin Blockchcain based on hadoopcryptoledgerlibrary. This is read-only for existing data. It returns BitcoinBlocks.
+  *
+  */
+class DefaultSource extends RelationProvider {
 
-class DefaultSource
-  extends RelationProvider
-   {
-
-	/**
+  /**
 	 * Used by Spark to fetch information about the data and initiate parsing
 	 *
 	*
 	*/
-  override def createRelation(
-      sqlContext: SQLContext,
-      parameters: Map[String, String]): BitcoinTransactionRelation = {
-      val path= parameters.getOrElse("path", sys.error("'path' must be specified with files containing Bitcoin blockchain data."))
-      val maxBlockSize = Integer.valueOf(parameters.getOrElse("maxBlockSize", String.valueOf(AbstractBitcoinRecordReader.DEFAULT_MAXSIZE_BITCOINBLOCK)))
-      val magic = parameters.getOrElse("magic", AbstractBitcoinRecordReader.DEFAULT_MAGIC)
-      val useDirectBuffer = parameters.getOrElse("useDirectBuffer", String.valueOf(AbstractBitcoinRecordReader.DEFAULT_USEDIRECTBUFFER)).toBoolean
-      val isSplitable = parameters.getOrElse("isSplitable", String.valueOf(AbstractBitcoinFileInputFormat.DEFAULT_ISSPLITABLE)).toBoolean
-      val readAuxPOW = parameters.getOrElse("readAuxPOW", String.valueOf(AbstractBitcoinRecordReader.DEFAULT_READAUXPOW)).toBoolean
-      // parse the parameters into hadoop objects
-      BitcoinTransactionRelation(path, maxBlockSize, magic, useDirectBuffer, isSplitable,readAuxPOW)(sqlContext)
+  override def createRelation(sqlContext: SQLContext, parameters: Map[String, String]): BitcoinTransactionRelation = {
+    val path =
+      parameters.getOrElse("path", sys.error("'path' must be specified with files containing Bitcoin blockchain data."))
+    val maxBlockSize = Integer.valueOf(
+      parameters.getOrElse("maxBlockSize", String.valueOf(AbstractBitcoinRecordReader.DEFAULT_MAXSIZE_BITCOINBLOCK)))
+    val magic = parameters.getOrElse("magic", AbstractBitcoinRecordReader.DEFAULT_MAGIC)
+    val useDirectBuffer = parameters
+      .getOrElse("useDirectBuffer", String.valueOf(AbstractBitcoinRecordReader.DEFAULT_USEDIRECTBUFFER))
+      .toBoolean
+    val isSplittable =
+      parameters.getOrElse("isSplittable", String.valueOf(AbstractBitcoinFileInputFormat.DEFAULT_ISSPLITABLE)).toBoolean
+    val readAuxPOW =
+      parameters.getOrElse("readAuxPOW", String.valueOf(AbstractBitcoinRecordReader.DEFAULT_READAUXPOW)).toBoolean
+    // parse the parameters into hadoop objects
+    BitcoinTransactionRelation(path, maxBlockSize, magic, useDirectBuffer, isSplittable, readAuxPOW)(sqlContext)
   }
-
 
 }

--- a/src/main/scala/org/zuinnote/spark/bitcoin/transaction/DefaultSource15.scala
+++ b/src/main/scala/org/zuinnote/spark/bitcoin/transaction/DefaultSource15.scala
@@ -1,40 +1,35 @@
 /**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+  * Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 package org.zuinnote.spark.bitcoin.transaction
 
 import org.apache.spark.sql.sources.DataSourceRegister
 
-import org.zuinnote.hadoop.bitcoin.format._
-   
 /**
-* Author: Jörn Franke <zuinnote@gmail.com>
-*
-*/
-
-/* Extension of DefaultSource (which is Spark 1.3 and 1.4 compatible) for Spark 1.5 compatibility.
- * Since the class is loaded through META-INF/services we can decouple the two to have
- * Spark 1.5 byte-code loaded lazily.
- *
- * This trick is adapted from spark elasticsearch-hadoop data source:
- * <https://github.com/elastic/elasticsearch-hadoop>
- */
+  * Author: Jörn Franke <zuinnote@gmail.com>
+  *
+  * Extension of DefaultSource (which is Spark 1.3 and 1.4 compatible) for Spark 1.5 compatibility.
+  * Since the class is loaded through META-INF/services we can decouple the two to have
+  * Spark 1.5 byte-code loaded lazily.
+  *
+  * This trick is adapted from spark elasticsearch-hadoop data source:
+  * <https://github.com/elastic/elasticsearch-hadoop>
+  */
 class DefaultSource15 extends DefaultSource with DataSourceRegister {
-
   /**
-   * Short alias for hadoopcryptoledger BitcoinTransaction data source.
-   */
+    * Short alias for hadoopcryptoledger BitcoinTransaction data source.
+    */
   override def shortName(): String = "bitcointransaction"
 }

--- a/src/main/scala/org/zuinnote/spark/bitcoin/transaction/package.scala
+++ b/src/main/scala/org/zuinnote/spark/bitcoin/transaction/package.scala
@@ -1,53 +1,46 @@
 /**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+  * Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
 **/
-package org.zuinnote.spark.bitcoin.transaction
-
+package org.zuinnote.spark.bitcoin
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
 
 import org.zuinnote.hadoop.bitcoin.format.common._
-import org.zuinnote.hadoop.bitcoin.format.mapreduce._   
-
-   
-/**
-* Author: Jörn Franke <zuinnote@gmail.com>
-*
-*/
-
-
-
-package object bitcointransaction {
+import org.zuinnote.hadoop.bitcoin.format.mapreduce._
 
 /**
-   * Adds a method, `bitcoinTransactionFile`, to SQLContext that allows reading Bitcoin blockchain data as Bitcoin transactions.
-   */
+  * Author: Jörn Franke <zuinnote@gmail.com>
+  *
+  */
+package object transaction {
 
- implicit class BitcoinTransactionContext(sqlContext: SQLContext) extends Serializable{
-def bitcoinTransactionFile(
+  /**
+    * Adds a method, `bitcoinTransactionFile`, to SQLContext that allows reading Bitcoin blockchain data as Bitcoin transactions.
+    */
+  implicit class BitcoinTransactionContext(sqlContext: SQLContext) extends Serializable {
+    def bitcoinTransactionFile(
         filePath: String,
-	maxBlockSize: Integer = AbstractBitcoinRecordReader.DEFAULT_MAXSIZE_BITCOINBLOCK,
-	magic: String = AbstractBitcoinRecordReader.DEFAULT_MAGIC,
-	useDirectBuffer: Boolean = AbstractBitcoinRecordReader.DEFAULT_USEDIRECTBUFFER,
-	isSplitable: Boolean = AbstractBitcoinFileInputFormat.DEFAULT_ISSPLITABLE
-       ): DataFrame = {
-      val bitcoinTransactionRelation = BitcoinTransactionRelation(filePath,maxBlockSize,magic,useDirectBuffer,isSplitable)(sqlContext)
+        maxBlockSize: Integer = AbstractBitcoinRecordReader.DEFAULT_MAXSIZE_BITCOINBLOCK,
+        magic: String = AbstractBitcoinRecordReader.DEFAULT_MAGIC,
+        useDirectBuffer: Boolean = AbstractBitcoinRecordReader.DEFAULT_USEDIRECTBUFFER,
+        isSplittable: Boolean = AbstractBitcoinFileInputFormat.DEFAULT_ISSPLITABLE
+    ): DataFrame = {
+      val bitcoinTransactionRelation =
+        BitcoinTransactionRelation(filePath, maxBlockSize, magic, useDirectBuffer, isSplittable)(sqlContext)
       sqlContext.baseRelationToDataFrame(bitcoinTransactionRelation)
-}
-}
-
-
+    }
+  }
 
 }

--- a/src/main/scala/org/zuinnote/spark/bitcoin/util/BitcoinBlockFile.scala
+++ b/src/main/scala/org/zuinnote/spark/bitcoin/util/BitcoinBlockFile.scala
@@ -1,43 +1,34 @@
 /**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
-
+  * Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 package org.zuinnote.spark.bitcoin.util
 
-
-
-
+import org.apache.hadoop.conf._
 import org.apache.hadoop.io.BytesWritable
-import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
-
-
-import org.apache.hadoop.io._
-import org.apache.hadoop.conf._
-
-
-import org.apache.hadoop.fs.Path
-
 import org.zuinnote.hadoop.bitcoin.format.common._
 import org.zuinnote.hadoop.bitcoin.format.mapreduce._
 
-
 private[bitcoin] object BitcoinBlockFile {
-
-  def load(context: SQLContext, location: String, hadoopConf: Configuration): RDD[(BytesWritable,BitcoinBlock)] = {
-	context.sparkContext.newAPIHadoopFile(location, classOf[BitcoinBlockFileInputFormat], classOf[BytesWritable], classOf[BitcoinBlock], hadoopConf);
-  }
+  def load(context: SQLContext, location: String, hadoopConf: Configuration): RDD[(BytesWritable, BitcoinBlock)] =
+    context.sparkContext.newAPIHadoopFile(
+      location,
+      classOf[BitcoinBlockFileInputFormat],
+      classOf[BytesWritable],
+      classOf[BitcoinBlock],
+      hadoopConf
+    )
 }

--- a/src/main/scala/org/zuinnote/spark/bitcoin/util/BitcoinTransactionFile.scala
+++ b/src/main/scala/org/zuinnote/spark/bitcoin/util/BitcoinTransactionFile.scala
@@ -1,42 +1,35 @@
 /**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
-
+  * Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 package org.zuinnote.spark.bitcoin.util
 
-
-
-
+import org.apache.hadoop.conf._
 import org.apache.hadoop.io.BytesWritable
-import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
-
-
-import org.apache.hadoop.io._
-import org.apache.hadoop.conf._
-
-
-import org.apache.hadoop.fs.Path
-
 import org.zuinnote.hadoop.bitcoin.format.common._
 import org.zuinnote.hadoop.bitcoin.format.mapreduce._
 
 private[bitcoin] object BitcoinTransactionFile {
 
-  def load(context: SQLContext, location: String, hadoopConf: Configuration): RDD[(BytesWritable,BitcoinTransaction)] = {
-	context.sparkContext.newAPIHadoopFile(location, classOf[BitcoinTransactionFileInputFormat], classOf[BytesWritable], classOf[BitcoinTransaction], hadoopConf);
-  }
+  def load(context: SQLContext, location: String, hadoopConf: Configuration): RDD[(BytesWritable, BitcoinTransaction)] =
+    context.sparkContext.newAPIHadoopFile(
+      location,
+      classOf[BitcoinTransactionFileInputFormat],
+      classOf[BytesWritable],
+      classOf[BitcoinTransaction],
+      hadoopConf
+    )
 }

--- a/src/main/scala/org/zuinnote/spark/ethereum/block/DefaultSource.scala
+++ b/src/main/scala/org/zuinnote/spark/ethereum/block/DefaultSource.scala
@@ -1,57 +1,45 @@
 /**
-* Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+  * Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 package org.zuinnote.spark.ethereum.block
 
-import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.{DataFrame, SaveMode, SQLContext}
+import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.sources._
-import org.apache.spark.sql.types.StructType
-
 import org.zuinnote.hadoop.ethereum.format.mapreduce._
 
 /**
-* Author: Jörn Franke <zuinnote@gmail.com>
-*
-*/
+  * Author: Jörn Franke <zuinnote@gmail.com>
+  *
+  * Defines a Spark data source for Ethereum Blockchcain based on hadoopcryptoledgerlibrary. This is read-only for existing data. It returns EthereumBlocks.
+  */
+class DefaultSource extends RelationProvider {
 
-/**
-*
-* Defines a Spark data source for Ethereum Blockchcain based on hadoopcryptoledgerlibrary. This is read-only for existing data. It returns EthereumBlocks.
-*
-*/
+  /**
+    * Used by Spark to fetch information about the data and initiate parsing
+    */
+  override def createRelation(sqlContext: SQLContext, parameters: Map[String, String]): EthereumBlockRelation = {
+    val path =
+      parameters.getOrElse("path", sys.error("'path' must be specified with files containing Bitcoin blockchain data."))
+    val maxBlockSize = Integer.valueOf(
+      parameters.getOrElse("maxBlockSize", String.valueOf(AbstractEthereumRecordReader.DEFAULT_MAXSIZE_ETHEREUMBLOCK)))
+    val useDirectBuffer = parameters
+      .getOrElse("useDirectBuffer", String.valueOf(AbstractEthereumRecordReader.DEFAULT_USEDIRECTBUFFER))
+      .toBoolean
+    val enrich = parameters.getOrElse("enrich", "false").toBoolean
 
-class DefaultSource
-  extends RelationProvider
-   {
-
-	/**
-	 * Used by Spark to fetch information about the data and initiate parsing
-	 *
-	*
-	*/
-  override def createRelation(
-      sqlContext: SQLContext,
-      parameters: Map[String, String]): EthereumBlockRelation = {
-      val path= parameters.getOrElse("path", sys.error("'path' must be specified with files containing Bitcoin blockchain data."))
-      val maxBlockSize = Integer.valueOf(parameters.getOrElse("maxBlockSize", String.valueOf(AbstractEthereumRecordReader.DEFAULT_MAXSIZE_ETHEREUMBLOCK)))
-      val useDirectBuffer = parameters.getOrElse("useDirectBuffer", String.valueOf(AbstractEthereumRecordReader.DEFAULT_USEDIRECTBUFFER)).toBoolean
-      val enrich = parameters.getOrElse("enrich", "false").toBoolean
-      // parse the parameters into hadoop objects
-      EthereumBlockRelation(path, maxBlockSize, useDirectBuffer, enrich)(sqlContext)
+    // parse the parameters into hadoop objects
+    EthereumBlockRelation(path, maxBlockSize, useDirectBuffer, enrich)(sqlContext)
   }
-
-
 }

--- a/src/main/scala/org/zuinnote/spark/ethereum/block/DefaultSource15.scala
+++ b/src/main/scala/org/zuinnote/spark/ethereum/block/DefaultSource15.scala
@@ -1,41 +1,35 @@
 /**
-* Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
-
+  * Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 package org.zuinnote.spark.ethereum.block
 
 import org.apache.spark.sql.sources.DataSourceRegister
 
-import org.zuinnote.hadoop.ethereum.format._
-
 /**
-* Author: Jörn Franke <zuinnote@gmail.com>
-*
-*/
-
-/* Extension of DefaultSource (which is Spark 1.3 and 1.4 compatible) for Spark 1.5 compatibility.
- * Since the class is loaded through META-INF/services we can decouple the two to have
- * Spark 1.5 byte-code loaded lazily.
- *
- * This trick is adapted from spark elasticsearch-hadoop data source:
- * <https://github.com/elastic/elasticsearch-hadoop>
- */
+  * Author: Jörn Franke <zuinnote@gmail.com>
+  *
+  * Extension of DefaultSource (which is Spark 1.3 and 1.4 compatible) for Spark 1.5 compatibility.
+  * Since the class is loaded through META-INF/services we can decouple the two to have
+  * Spark 1.5 byte-code loaded lazily.
+  *
+  * This trick is adapted from spark elasticsearch-hadoop data source:
+  * <https://github.com/elastic/elasticsearch-hadoop>
+  */
 class DefaultSource15 extends DefaultSource with DataSourceRegister {
-
   /**
-   * Short alias for hadoopcryptoledger BitcoinBlock data source.
-   */
+    * Short alias for hadoopcryptoledger BitcoinBlock data source.
+    */
   override def shortName(): String = "ethereumblock"
 }

--- a/src/main/scala/org/zuinnote/spark/ethereum/block/EthereumBlockRelation.scala
+++ b/src/main/scala/org/zuinnote/spark/ethereum/block/EthereumBlockRelation.scala
@@ -1,260 +1,272 @@
 /**
-* Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+  * Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 package org.zuinnote.spark.ethereum.block
 
-import scala.collection.JavaConversions._
-
-
-import org.apache.spark.sql.sources.{BaseRelation,TableScan}
-import org.apache.spark.sql.types.DataType
-import org.apache.spark.sql.types.ArrayType
-import org.apache.spark.sql.types.ByteType
-import org.apache.spark.sql.types.BinaryType
-import org.apache.spark.sql.types.IntegerType
-import org.apache.spark.sql.types.LongType
-import org.apache.spark.sql.types.StructField
-import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.SQLContext
-
-import org.apache.spark.sql._
-import org.apache.spark.rdd.RDD
-
-import org.apache.hadoop.conf._
-import org.apache.hadoop.mapred._
-
-
-
 import org.apache.commons.logging.LogFactory
-import org.apache.commons.logging.Log
-
-
+import org.apache.hadoop.conf._
+import org.apache.hadoop.io.BytesWritable
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.sources.{BaseRelation, TableScan}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{SQLContext, _}
 import org.zuinnote.hadoop.ethereum.format.common._
 import org.zuinnote.hadoop.ethereum.format.mapreduce._
 import org.zuinnote.spark.ethereum.util.EthereumBlockFile
 
-/**
-* Author: Jörn Franke <zuinnote@gmail.com>
-*
-*/
+import scala.collection.JavaConversions._
 
 /**
-* Defines the schema of a EthereumBlock for Spark SQL
-*
-*/
+  * Author: Jörn Franke <zuinnote@gmail.com>
+  *
+  */
+/**
+  * Defines the schema of a EthereumBlock for Spark SQL
+  *
+  */
+case class EthereumBlockRelation(location: String,
+                                 maxBlockSize: Integer = AbstractEthereumRecordReader.DEFAULT_MAXSIZE_ETHEREUMBLOCK,
+                                 useDirectBuffer: Boolean = AbstractEthereumRecordReader.DEFAULT_USEDIRECTBUFFER,
+                                 enrich: Boolean = false)(@transient val sqlContext: SQLContext)
+  extends BaseRelation with TableScan with Serializable {
 
-case class EthereumBlockRelation(location: String,maxBlockSize: Integer = AbstractEthereumRecordReader.DEFAULT_MAXSIZE_ETHEREUMBLOCK,useDirectBuffer: Boolean = AbstractEthereumRecordReader.DEFAULT_USEDIRECTBUFFER, enrich: Boolean = false)
-(@transient val sqlContext: SQLContext)
-  extends BaseRelation with TableScan
-       with Serializable {
-  val LOG = LogFactory.getLog(EthereumBlockRelation.getClass);
+  private lazy val LOG = LogFactory.getLog(EthereumBlockRelation.getClass)
 
   override def schema: StructType = {
-    val structEthereum = StructType(Seq(
-      StructField("ethereumBlockHeader",StructType(Seq(
-                StructField("parentHash",BinaryType,false),
-                StructField("uncleHash",BinaryType,false),
-                StructField("coinBase",BinaryType,false),
-                StructField("stateRoot",BinaryType,false),
-                StructField("txTrieRoot",BinaryType,false),
-                StructField("receiptTrieRoot",BinaryType,false),
-                StructField("logsBloom",BinaryType,false),
-                StructField("difficulty",BinaryType,false),
-                StructField("timestamp",LongType,false),
-                StructField("number",LongType,false),
-                StructField("gasLimit",LongType,false),
-                StructField("gasUsed",LongType,false),
-                StructField("mixHash",BinaryType,false),
-                StructField("extraData",BinaryType,false),
-                StructField("nonce",BinaryType,false)
-      )),false),
-      StructField("ethereumTransactions",ArrayType(StructType(Seq(
-                StructField("nonce",BinaryType,false),
-                StructField("value",LongType,false),
-                StructField("receiveAddress",BinaryType,false),
-                StructField("gasPrice",LongType,false),
-                StructField("gasLimit",LongType,false),
-                StructField("data",BinaryType,false),
-                StructField("sig_v",BinaryType,false),
-                StructField("sig_r",BinaryType,false),
-                StructField("sig_s",BinaryType,false)
-      ))),false),
-        StructField("uncleHeaders",ArrayType(StructType(Seq(
-                StructField("parentHash",BinaryType,false),
-                StructField("uncleHash",BinaryType,false),
-                StructField("coinBase",BinaryType,false),
-                StructField("stateRoot",BinaryType,false),
-                StructField("txTrieRoot",BinaryType,false),
-                StructField("receiptTrieRoot",BinaryType,false),
-                StructField("logsBloom",BinaryType,false),
-                StructField("difficulty",BinaryType,false),
-                StructField("timestamp",LongType,false),
-                StructField("number",LongType,false),
-                StructField("gasLimit",LongType,false),
-                StructField("gasUsed",LongType,false),
-                StructField("mixHash",BinaryType,false),
-                StructField("extraData",BinaryType,false),
-                StructField("nonce",BinaryType,false)
-        ))),false)))
-
-        val structEthereumEnrich = StructType(Seq(
-          StructField("ethereumBlockHeader",StructType(Seq(
-                    StructField("parentHash",BinaryType,false),
-                    StructField("uncleHash",BinaryType,false),
-                    StructField("coinBase",BinaryType,false),
-                    StructField("stateRoot",BinaryType,false),
-                    StructField("txTrieRoot",BinaryType,false),
-                    StructField("receiptTrieRoot",BinaryType,false),
-                    StructField("logsBloom",BinaryType,false),
-                    StructField("difficulty",BinaryType,false),
-                    StructField("timestamp",LongType,false),
-                    StructField("number",LongType,false),
-                    StructField("gasLimit",LongType,false),
-                    StructField("gasUsed",LongType,false),
-                    StructField("mixHash",BinaryType,false),
-                    StructField("extraData",BinaryType,false),
-                    StructField("nonce",BinaryType,false)
-          )),false),
-          StructField("ethereumTransactions",ArrayType(StructType(Seq(
-                    StructField("nonce",BinaryType,false),
-                    StructField("value",LongType,false),
-                    StructField("receiveAddress",BinaryType,false),
-                    StructField("gasPrice",LongType,false),
-                    StructField("gasLimit",LongType,false),
-                    StructField("data",BinaryType,false),
-                    StructField("sig_v",BinaryType,false),
-                    StructField("sig_r",BinaryType,false),
-                    StructField("sig_s",BinaryType,false),
-                    StructField("sendAddress",BinaryType,false),
-                    StructField("hash",BinaryType,false)
-          ))),false),
-            StructField("uncleHeaders",ArrayType(StructType(Seq(
-                    StructField("parentHash",BinaryType,false),
-                    StructField("uncleHash",BinaryType,false),
-                    StructField("coinBase",BinaryType,false),
-                    StructField("stateRoot",BinaryType,false),
-                    StructField("txTrieRoot",BinaryType,false),
-                    StructField("receiptTrieRoot",BinaryType,false),
-                    StructField("logsBloom",BinaryType,false),
-                    StructField("difficulty",BinaryType,false),
-                    StructField("timestamp",LongType,false),
-                    StructField("number",LongType,false),
-                    StructField("gasLimit",LongType,false),
-                    StructField("gasUsed",LongType,false),
-                    StructField("mixHash",BinaryType,false),
-                    StructField("extraData",BinaryType,false),
-                    StructField("nonce",BinaryType,false)
-            ))),false)))
-    if (enrich) {
-      return structEthereumEnrich
-    } else {
-      return structEthereum
-    }
-    }
-
-
-
-    /**
-     * Used by Spark to fetch Ethereum blocks according to the schema specified above from files.
-     *
-     *
-     * returns EthereumBlocks as rows
-    **/
-    override def buildScan: RDD[Row] = {
-	// create hadoopConf
-	val hadoopConf = new Configuration()
- 	hadoopConf.set(AbstractEthereumRecordReader.CONF_MAXBLOCKSIZE,String.valueOf(maxBlockSize))
- 	hadoopConf.set(AbstractEthereumRecordReader.CONF_USEDIRECTBUFFER,String.valueOf(useDirectBuffer))
-        // read BitcoinBlock
-	val ethereumBlockRDD = EthereumBlockFile.load(sqlContext, location, hadoopConf)
-        // map to schema
-	val schemaFields = schema.fields
-	val rowArray = new Array[Any](schemaFields.length)
-        ethereumBlockRDD.flatMap(hadoopKeyValueTuple => {
-		// map the EthereumBlock data structure to a Spark SQL schema
-    val ethereumBlockStructArray = new Array[Any](3)
-    val ethereumBlockHeaderStructArray = new Array[Any](15)
-    ethereumBlockHeaderStructArray(0) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getParentHash
-    ethereumBlockHeaderStructArray(1) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getUncleHash
-    ethereumBlockHeaderStructArray(2) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getCoinBase
-    ethereumBlockHeaderStructArray(3) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getStateRoot
-    ethereumBlockHeaderStructArray(4) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getTxTrieRoot
-    ethereumBlockHeaderStructArray(5) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getReceiptTrieRoot
-    ethereumBlockHeaderStructArray(6) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getLogsBloom
-    ethereumBlockHeaderStructArray(7) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getDifficulty
-    ethereumBlockHeaderStructArray(8) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getTimestamp
-    ethereumBlockHeaderStructArray(9) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getNumber
-    ethereumBlockHeaderStructArray(10) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getGasLimit
-    ethereumBlockHeaderStructArray(11) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getGasUsed
-    ethereumBlockHeaderStructArray(12) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getMixHash
-    ethereumBlockHeaderStructArray(13) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getExtraData
-    ethereumBlockHeaderStructArray(14) = hadoopKeyValueTuple._2.getEthereumBlockHeader.getNonce
-    rowArray(0)= Row.fromSeq(ethereumBlockHeaderStructArray)
-    val ethereumTransactionArray=new Array[Any](hadoopKeyValueTuple._2.getEthereumTransactions().size())
-    var i=0
-    for (currentTransaction <- hadoopKeyValueTuple._2.getEthereumTransactions()) {
-        var ethereumTransactionStructArray = new Array[Any](9)
-        if (enrich) {
-            ethereumTransactionStructArray = new Array[Any](11)
-        }
-        ethereumTransactionStructArray(0) = currentTransaction.getNonce
-        ethereumTransactionStructArray(1) = currentTransaction.getValue
-        ethereumTransactionStructArray(2) = currentTransaction.getReceiveAddress
-        ethereumTransactionStructArray(3) = currentTransaction.getGasPrice
-        ethereumTransactionStructArray(4) = currentTransaction.getGasLimit
-        ethereumTransactionStructArray(5) = currentTransaction.getData
-        ethereumTransactionStructArray(6) = currentTransaction.getSig_v
-        ethereumTransactionStructArray(7) = currentTransaction.getSig_r
-        ethereumTransactionStructArray(8) = currentTransaction.getSig_s
-        if (enrich) {
-          ethereumTransactionStructArray(9) = EthereumUtil.getSendAddress(currentTransaction)
-          ethereumTransactionStructArray(10) = EthereumUtil.getTransactionHash(currentTransaction)
-        }
-        ethereumTransactionArray(i)=Row.fromSeq(ethereumTransactionStructArray)
-        i += 1
-    }
-    rowArray(1) = ethereumTransactionArray
-    val uncleHeadersArray = new Array[Any](hadoopKeyValueTuple._2.getUncleHeaders().size())
-    i=0
-    for (currentUncleHeader <- hadoopKeyValueTuple._2.getUncleHeaders()) {
-      val ethereumUncleHeaderStructArray = new Array[Any](15)
-      ethereumUncleHeaderStructArray(0) = currentUncleHeader.getParentHash
-      ethereumUncleHeaderStructArray(1) = currentUncleHeader.getUncleHash
-      ethereumUncleHeaderStructArray(2) = currentUncleHeader.getCoinBase
-      ethereumUncleHeaderStructArray(3) = currentUncleHeader.getStateRoot
-      ethereumUncleHeaderStructArray(4) = currentUncleHeader.getTxTrieRoot
-      ethereumUncleHeaderStructArray(5) = currentUncleHeader.getReceiptTrieRoot
-      ethereumUncleHeaderStructArray(6) = currentUncleHeader.getLogsBloom
-      ethereumUncleHeaderStructArray(7) = currentUncleHeader.getDifficulty
-      ethereumUncleHeaderStructArray(8) = currentUncleHeader.getTimestamp
-      ethereumUncleHeaderStructArray(9) = currentUncleHeader.getNumber
-      ethereumUncleHeaderStructArray(10) = currentUncleHeader.getGasLimit
-      ethereumUncleHeaderStructArray(11) = currentUncleHeader.getGasUsed
-      ethereumUncleHeaderStructArray(12) = currentUncleHeader.getMixHash
-      ethereumUncleHeaderStructArray(13) = currentUncleHeader.getExtraData
-      ethereumUncleHeaderStructArray(14) = currentUncleHeader.getNonce
-      uncleHeadersArray(i)= Row.fromSeq(ethereumUncleHeaderStructArray)
-      i += 1
-    }
-    rowArray(2) = uncleHeadersArray
-	 	// add row representing one Ethereum Block
-          	Some(Row.fromSeq(rowArray))
-		}
+    val structEthereum = StructType(
+      Seq(
+        StructField(
+          "ethereumBlockHeader",
+          StructType(Seq(
+            StructField("parentHash", BinaryType, nullable = false),
+            StructField("uncleHash", BinaryType, nullable = false),
+            StructField("coinBase", BinaryType, nullable = false),
+            StructField("stateRoot", BinaryType, nullable = false),
+            StructField("txTrieRoot", BinaryType, nullable = false),
+            StructField("receiptTrieRoot", BinaryType, nullable = false),
+            StructField("logsBloom", BinaryType, nullable = false),
+            StructField("difficulty", BinaryType, nullable = false),
+            StructField("timestamp", LongType, nullable = false),
+            StructField("number", LongType, nullable = false),
+            StructField("gasLimit", LongType, nullable = false),
+            StructField("gasUsed", LongType, nullable = false),
+            StructField("mixHash", BinaryType, nullable = false),
+            StructField("extraData", BinaryType, nullable = false),
+            StructField("nonce", BinaryType, nullable = false)
+          )),
+          nullable = false
+        ),
+        StructField(
+          "ethereumTransactions",
+          ArrayType(StructType(Seq(
+            StructField("nonce", BinaryType, nullable = false),
+            StructField("value", LongType, nullable = false),
+            StructField("receiveAddress", BinaryType, nullable = false),
+            StructField("gasPrice", LongType, nullable = false),
+            StructField("gasLimit", LongType, nullable = false),
+            StructField("data", BinaryType, nullable = false),
+            StructField("sig_v", BinaryType, nullable = false),
+            StructField("sig_r", BinaryType, nullable = false),
+            StructField("sig_s", BinaryType, nullable = false)
+          ))),
+          nullable = false
+        ),
+        StructField(
+          "uncleHeaders",
+          ArrayType(StructType(Seq(
+            StructField("parentHash", BinaryType, nullable = false),
+            StructField("uncleHash", BinaryType, nullable = false),
+            StructField("coinBase", BinaryType, nullable = false),
+            StructField("stateRoot", BinaryType, nullable = false),
+            StructField("txTrieRoot", BinaryType, nullable = false),
+            StructField("receiptTrieRoot", BinaryType, nullable = false),
+            StructField("logsBloom", BinaryType, nullable = false),
+            StructField("difficulty", BinaryType, nullable = false),
+            StructField("timestamp", LongType, nullable = false),
+            StructField("number", LongType, nullable = false),
+            StructField("gasLimit", LongType, nullable = false),
+            StructField("gasUsed", LongType, nullable = false),
+            StructField("mixHash", BinaryType, nullable = false),
+            StructField("extraData", BinaryType, nullable = false),
+            StructField("nonce", BinaryType, nullable = false)
+          ))),
+          nullable = false
         )
+      ))
 
-     }
+    val structEthereumEnrich = StructType(
+      Seq(
+        StructField(
+          "ethereumBlockHeader",
+          StructType(Seq(
+            StructField("parentHash", BinaryType, nullable = false),
+            StructField("uncleHash", BinaryType, nullable = false),
+            StructField("coinBase", BinaryType, nullable = false),
+            StructField("stateRoot", BinaryType, nullable = false),
+            StructField("txTrieRoot", BinaryType, nullable = false),
+            StructField("receiptTrieRoot", BinaryType, nullable = false),
+            StructField("logsBloom", BinaryType, nullable = false),
+            StructField("difficulty", BinaryType, nullable = false),
+            StructField("timestamp", LongType, nullable = false),
+            StructField("number", LongType, nullable = false),
+            StructField("gasLimit", LongType, nullable = false),
+            StructField("gasUsed", LongType, nullable = false),
+            StructField("mixHash", BinaryType, nullable = false),
+            StructField("extraData", BinaryType, nullable = false),
+            StructField("nonce", BinaryType, nullable = false)
+          )),
+          nullable = false
+        ),
+        StructField(
+          "ethereumTransactions",
+          ArrayType(StructType(Seq(
+            StructField("nonce", BinaryType, nullable = false),
+            StructField("value", LongType, nullable = false),
+            StructField("receiveAddress", BinaryType, nullable = false),
+            StructField("gasPrice", LongType, nullable = false),
+            StructField("gasLimit", LongType, nullable = false),
+            StructField("data", BinaryType, nullable = false),
+            StructField("sig_v", BinaryType, nullable = false),
+            StructField("sig_r", BinaryType, nullable = false),
+            StructField("sig_s", BinaryType, nullable = false),
+            StructField("sendAddress", BinaryType, nullable = false),
+            StructField("hash", BinaryType, nullable = false)
+          ))),
+          nullable = false
+        ),
+        StructField(
+          "uncleHeaders",
+          ArrayType(StructType(Seq(
+            StructField("parentHash", BinaryType, nullable = false),
+            StructField("uncleHash", BinaryType, nullable = false),
+            StructField("coinBase", BinaryType, nullable = false),
+            StructField("stateRoot", BinaryType, nullable = false),
+            StructField("txTrieRoot", BinaryType, nullable = false),
+            StructField("receiptTrieRoot", BinaryType, nullable = false),
+            StructField("logsBloom", BinaryType, nullable = false),
+            StructField("difficulty", BinaryType, nullable = false),
+            StructField("timestamp", LongType, nullable = false),
+            StructField("number", LongType, nullable = false),
+            StructField("gasLimit", LongType, nullable = false),
+            StructField("gasUsed", LongType, nullable = false),
+            StructField("mixHash", BinaryType, nullable = false),
+            StructField("extraData", BinaryType, nullable = false),
+            StructField("nonce", BinaryType, nullable = false)
+          ))),
+          nullable = false
+        )
+      ))
 
+    if (enrich) {
+      structEthereumEnrich
+    } else {
+      structEthereum
+    }
+  }
 
+  /**
+    * Used by Spark to fetch Ethereum blocks according to the schema specified above from files.
+    *
+    *
+    * returns EthereumBlocks as rows
+    **/
+  override def buildScan: RDD[Row] = {
+    val ethereumBlockRDD: RDD[(BytesWritable, EthereumBlock)] = readRawBlockRDD()
+
+    // map to schema
+    ethereumBlockRDD.map { case (_, block) =>
+      // map the EthereumBlock data structure to a Spark SQL schema
+      val header = Seq(
+        block.getEthereumBlockHeader.getParentHash,
+        block.getEthereumBlockHeader.getUncleHash,
+        block.getEthereumBlockHeader.getCoinBase,
+        block.getEthereumBlockHeader.getStateRoot,
+        block.getEthereumBlockHeader.getTxTrieRoot,
+        block.getEthereumBlockHeader.getReceiptTrieRoot,
+        block.getEthereumBlockHeader.getLogsBloom,
+        block.getEthereumBlockHeader.getDifficulty,
+        block.getEthereumBlockHeader.getTimestamp,
+        block.getEthereumBlockHeader.getNumber,
+        block.getEthereumBlockHeader.getGasLimit,
+        block.getEthereumBlockHeader.getGasUsed,
+        block.getEthereumBlockHeader.getMixHash,
+        block.getEthereumBlockHeader.getExtraData,
+        block.getEthereumBlockHeader.getNonce
+      )
+
+      val transactions = block.getEthereumTransactions
+        .map { currentTransaction =>
+          val transaction = Seq(
+            currentTransaction.getNonce,
+            currentTransaction.getValue,
+            currentTransaction.getReceiveAddress,
+            currentTransaction.getGasPrice,
+            currentTransaction.getGasLimit,
+            currentTransaction.getData,
+            currentTransaction.getSig_v,
+            currentTransaction.getSig_r,
+            currentTransaction.getSig_s
+          )
+
+          if (enrich) {
+            transaction ++ Seq(
+              EthereumUtil.getSendAddress(currentTransaction),
+              EthereumUtil.getTransactionHash(currentTransaction)
+            )
+          } else {
+            transaction
+          }
+        }
+
+      val uncleHeaders = block.getUncleHeaders
+        .map { uncleHeader =>
+          Seq(
+            uncleHeader.getParentHash,
+            uncleHeader.getUncleHash,
+            uncleHeader.getCoinBase,
+            uncleHeader.getStateRoot,
+            uncleHeader.getTxTrieRoot,
+            uncleHeader.getReceiptTrieRoot,
+            uncleHeader.getLogsBloom,
+            uncleHeader.getDifficulty,
+            uncleHeader.getTimestamp,
+            uncleHeader.getNumber,
+            uncleHeader.getGasLimit,
+            uncleHeader.getGasUsed,
+            uncleHeader.getMixHash,
+            uncleHeader.getExtraData,
+            uncleHeader.getNonce
+          )
+        }
+
+      // add row representing one Ethereum Block
+      Seq(
+        Row.fromSeq(header),
+        transactions.map(Row.fromSeq).toArray,
+        uncleHeaders.map(Row.fromSeq).toArray
+      )
+    }
+    .map(Row.fromSeq)
+  }
+
+  private def readRawBlockRDD(): RDD[(BytesWritable, EthereumBlock)] = {
+    // create hadoopConf
+    val hadoopConf = new Configuration()
+    hadoopConf.set(AbstractEthereumRecordReader.CONF_MAXBLOCKSIZE, String.valueOf(maxBlockSize))
+    hadoopConf.set(AbstractEthereumRecordReader.CONF_USEDIRECTBUFFER, String.valueOf(useDirectBuffer))
+    // read Ethereum Block
+    EthereumBlockFile.load(sqlContext, location, hadoopConf)
+  }
 }

--- a/src/main/scala/org/zuinnote/spark/ethereum/block/package.scala
+++ b/src/main/scala/org/zuinnote/spark/ethereum/block/package.scala
@@ -1,49 +1,42 @@
 /**
-* Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+  * Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
 **/
-
-package org.zuinnote.spark.ethereum.block
-
+package org.zuinnote.spark.ethereum
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
 
 import org.zuinnote.hadoop.ethereum.format.common._
 import org.zuinnote.hadoop.ethereum.format.mapreduce._
 
-
 /**
-* Author: Jörn Franke <zuinnote@gmail.com>
-*
-*/
+  * Author: Jörn Franke <zuinnote@gmail.com>
+  *
+  */
+package object block {
 
-
-
-package object ethereumblock {
-
-/**
-   * Adds a method, `etheruemBlockFile`, to SQLContext that allows reading Etheruem blockchain data as Ethereum blocks.
-   */
-
- implicit class EthereumBlockContext(sqlContext: SQLContext) extends Serializable{
-def ethereumBlockFile(
+  /**
+    * Adds a method, `etheruemBlockFile`, to SQLContext that allows reading Etheruem blockchain data as Ethereum blocks.
+    */
+  implicit class EthereumBlockContext(sqlContext: SQLContext) extends Serializable {
+    def ethereumBlockFile(
         filePath: String,
-	maxBlockSize: Integer = AbstractEthereumRecordReader.DEFAULT_MAXSIZE_ETHEREUMBLOCK,
-	useDirectBuffer: Boolean = AbstractEthereumRecordReader.DEFAULT_USEDIRECTBUFFER
-       ): DataFrame = {
-      val ethereumBlockRelation = EthereumBlockRelation(filePath,maxBlockSize,useDirectBuffer)(sqlContext)
+        maxBlockSize: Integer = AbstractEthereumRecordReader.DEFAULT_MAXSIZE_ETHEREUMBLOCK,
+        useDirectBuffer: Boolean = AbstractEthereumRecordReader.DEFAULT_USEDIRECTBUFFER
+    ): DataFrame = {
+      val ethereumBlockRelation = EthereumBlockRelation(filePath, maxBlockSize, useDirectBuffer)(sqlContext)
       sqlContext.baseRelationToDataFrame(ethereumBlockRelation)
-}
-}
+    }
+  }
 }

--- a/src/main/scala/org/zuinnote/spark/ethereum/util/EthereumBlockFile.scala
+++ b/src/main/scala/org/zuinnote/spark/ethereum/util/EthereumBlockFile.scala
@@ -1,44 +1,34 @@
 /**
-* Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
-
-
+  * Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 package org.zuinnote.spark.ethereum.util
 
-
-
-
+import org.apache.hadoop.conf._
 import org.apache.hadoop.io.BytesWritable
-import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
-
-
-import org.apache.hadoop.io._
-import org.apache.hadoop.conf._
-
-
-import org.apache.hadoop.fs.Path
-
 import org.zuinnote.hadoop.ethereum.format.common._
 import org.zuinnote.hadoop.ethereum.format.mapreduce._
 
-
 private[ethereum] object EthereumBlockFile {
-
-  def load(context: SQLContext, location: String, hadoopConf: Configuration): RDD[(BytesWritable,EthereumBlock)] = {
-	context.sparkContext.newAPIHadoopFile(location, classOf[EthereumBlockFileInputFormat], classOf[BytesWritable], classOf[EthereumBlock], hadoopConf);
-  }
+  def load(context: SQLContext, location: String, hadoopConf: Configuration): RDD[(BytesWritable, EthereumBlock)] =
+    context.sparkContext.newAPIHadoopFile(
+      location,
+      classOf[EthereumBlockFileInputFormat],
+      classOf[BytesWritable],
+      classOf[EthereumBlock],
+      hadoopConf
+    )
 }

--- a/src/test/scala/org/zuinnote/spark/bitcoin/block/SparkBitcoinBlockDSSpec.scala
+++ b/src/test/scala/org/zuinnote/spark/bitcoin/block/SparkBitcoinBlockDSSpec.scala
@@ -1,50 +1,42 @@
 /**
-* Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+  * Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 /**
-*
-* This test "unit tests" the application with a local Spark master
-*
-*/
+  *
+  * This test "unit tests" the application with a local Spark master
+  *
+  */
 package org.zuinnote.spark.bitcoin.block
 
-import org.scalatest.{FlatSpec, BeforeAndAfterAll, GivenWhenThen, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, GivenWhenThen, Matchers}
 
+class SparkBitcoinBlockDSSpec extends FlatSpec with BeforeAndAfterAll with GivenWhenThen with Matchers {
 
-class SparkBitcoinBlockDSSpec extends FlatSpec with BeforeAndAfterAll with GivenWhenThen with Matchers  {
-
-
-override def beforeAll(): Unit = {
+  override def beforeAll(): Unit = {
     super.beforeAll()
+  }
 
- }
-
-  
   override def afterAll(): Unit = {
 
     super.afterAll()
-}
+  }
 
-
-
-"Simple Test" should "be alway successful" in {
-	Given("Nothing")
-	Then("success")
-	// fetch results
-	assert(1==1)
-}
-
-
+  "Simple Test" should "be alway successful" in {
+    Given("Nothing")
+    Then("success")
+    // fetch results
+    assert(1 == 1)
+  }
 }

--- a/src/test/scala/org/zuinnote/spark/bitcoin/transaction/SparkBitcoinTransactionDSSpec.scala
+++ b/src/test/scala/org/zuinnote/spark/bitcoin/transaction/SparkBitcoinTransactionDSSpec.scala
@@ -1,50 +1,42 @@
 /**
-* Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+  * Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 /**
-*
-* This test "unit tests" the application with a local Spark master
-*
-*/
-package org.zuinnote.spark.bitcoin.block
+  *
+  * This test "unit tests" the application with a local Spark master
+  *
+  */
+package org.zuinnote.spark.bitcoin.transaction
 
-import org.scalatest.{FlatSpec, BeforeAndAfterAll, GivenWhenThen, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, GivenWhenThen, Matchers}
 
+class SparkBitcoinTransactionDSSpec extends FlatSpec with BeforeAndAfterAll with GivenWhenThen with Matchers {
 
-class SparkBitcoinTransactionDSSpec extends FlatSpec with BeforeAndAfterAll with GivenWhenThen with Matchers  {
-
-
-override def beforeAll(): Unit = {
+  override def beforeAll(): Unit = {
     super.beforeAll()
+  }
 
- }
-
-  
   override def afterAll(): Unit = {
 
     super.afterAll()
-}
+  }
 
-
-
-"Simple Test" should "be alway successful" in {
-	Given("Nothing")
-	Then("success")
-	// fetch results
-	assert(1==1)
-}
-
-
+  "Simple Test" should "be alway successful" in {
+    Given("Nothing")
+    Then("success")
+    // fetch results
+    assert(1 == 1)
+  }
 }

--- a/src/test/scala/org/zuinnote/spark/ethereum/block/SparkEthereumBlockDSSpec.scala
+++ b/src/test/scala/org/zuinnote/spark/ethereum/block/SparkEthereumBlockDSSpec.scala
@@ -1,50 +1,41 @@
 /**
-* Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+  * Copyright 2017 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  **/
 /**
-*
-* This test "unit tests" the application with a local Spark master
-*
-*/
+  *
+  * This test "unit tests" the application with a local Spark master
+  *
+  */
 package org.zuinnote.spark.ethereum.block
 
-import org.scalatest.{FlatSpec, BeforeAndAfterAll, GivenWhenThen, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, GivenWhenThen, Matchers}
 
-
-class SparkEthereumBlockDSSpec extends FlatSpec with BeforeAndAfterAll with GivenWhenThen with Matchers  {
-
-
-override def beforeAll(): Unit = {
+class SparkEthereumBlockDSSpec extends FlatSpec with BeforeAndAfterAll with GivenWhenThen with Matchers {
+  override def beforeAll(): Unit = {
     super.beforeAll()
-
- }
-
+  }
 
   override def afterAll(): Unit = {
 
     super.afterAll()
-}
+  }
 
-
-
-"Simple Test" should "be alway successful" in {
-	Given("Nothing")
-	Then("success")
-	// fetch results
-	assert(1==1)
-}
-
-
+  "Simple Test" should "be alway successful" in {
+    Given("Nothing")
+    Then("success")
+    // fetch results
+    assert(1 == 1)
+  }
 }


### PR DESCRIPTION
1. Add plugins for code formatting, linting, etc.
2. Canonicalize Scala code (remove `for`s, `return`s, mutable state, etc.)

(This is a rolling pull request)