### PR TITLE
Fixed compile error when compiling for 2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,8 +46,8 @@ lazy val root = (project in file("."))
     ),
     scalacOptions --= // scalac 2.10 rejects some HK types under -Xfuture it seems..
       (CrossVersion partialVersion scalaVersion.value collect {
-      case (2, 10) => List("-Ywarn-unused", "-Ywarn-unused-import")
-    }).toList.flatten,
+        case (2, 10) => List("-Ywarn-unused", "-Ywarn-unused-import", "-Ywarn-numeric-widen")
+      }).toList.flatten,
 
     javaOptions += "-Xmx3G",
 


### PR DESCRIPTION
This was an issue in Scala itself, where it shows false positives for a warning. Fixed in Scala 2.11, but that doesn't help us.